### PR TITLE
fix: typing, recording-audio & reactions silently dropped (canonical JID)

### DIFF
--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -52,6 +52,10 @@ type ChatPresenceStruct struct {
 	Number  string `json:"number"`
 	State   string `json:"state"`
 	IsAudio bool   `json:"isAudio"`
+	// Delay, in milliseconds, keeps the "composing"/"recording" indicator alive
+	// for the given duration (re-sending it periodically) and then sends "paused".
+	// Only applies when State is "composing". 0 = single fire (legacy behaviour).
+	Delay int `json:"delay"`
 }
 
 type MarkReadStruct struct {
@@ -221,18 +225,70 @@ func (m *messageService) ChatPresence(data *ChatPresenceStruct, instance *instan
 		return "", errors.New("invalid phone number")
 	}
 
+	// chatstate (typing) is a RAW node sent without usync normalization, so it
+	// needs a canonical digits-only JID or WhatsApp silently drops it. See
+	// utils.CanonicalJID for the full rationale.
+	recipient = utils.CanonicalJID(recipient)
+
 	media := ""
 
 	if data.IsAudio {
 		media = "audio"
 	}
 
-	err = client.SendChatPresence(context.Background(), recipient, types.ChatPresence(data.State), types.ChatPresenceMedia(media))
+	// WhatsApp only forwards chatstate (typing / recording) events to the
+	// recipient while the sender is marked online. SendChatPresence merely
+	// sends the chatstate node — it does NOT mark us available. Background
+	// presence handling (events.AppStateSyncComplete) may have set us to
+	// Unavailable, in which case the server silently drops the typing
+	// indicator. Mark ourselves available first to guarantee delivery.
+	if presErr := client.SendPresence(context.Background(), types.PresenceAvailable); presErr != nil {
+		m.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] SendPresence(available) before chatstate failed (non-fatal): %v", instance.Id, presErr)
+	}
+
+	state := types.ChatPresence(data.State)
+	mediaType := types.ChatPresenceMedia(media)
+
+	err = client.SendChatPresence(context.Background(), recipient, state, mediaType)
 	if err != nil {
 		return "", err
 	}
 
-	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Message sent to %s", data.Number)
+	// A single "composing" indicator is ephemeral: WhatsApp expires it after a
+	// few seconds unless refreshed. When a Delay is provided (and we're typing),
+	// keep the indicator alive for the requested duration by re-sending it, then
+	// send "paused" so the indicator clears cleanly instead of timing out.
+	if data.Delay > 0 && state == types.ChatPresenceComposing {
+		const keepAliveInterval = 5 * time.Second
+		const maxDelay = 60 * time.Second
+
+		remaining := time.Duration(data.Delay) * time.Millisecond
+		if remaining > maxDelay {
+			remaining = maxDelay
+		}
+
+		for remaining > 0 {
+			sleep := keepAliveInterval
+			if remaining < sleep {
+				sleep = remaining
+			}
+			time.Sleep(sleep)
+			remaining -= sleep
+
+			if remaining > 0 {
+				// Refresh the indicator so it doesn't expire mid-delay.
+				if refreshErr := client.SendChatPresence(context.Background(), recipient, state, mediaType); refreshErr != nil {
+					m.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Refresh chatstate failed (non-fatal): %v", instance.Id, refreshErr)
+				}
+			}
+		}
+
+		if pausedErr := client.SendChatPresence(context.Background(), recipient, types.ChatPresencePaused, mediaType); pausedErr != nil {
+			m.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] SendChatPresence(paused) failed (non-fatal): %v", instance.Id, pausedErr)
+		}
+	}
+
+	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Presence (%s) sent to %s", data.State, data.Number)
 
 	return ts.String(), nil
 }
@@ -250,6 +306,10 @@ func (m *messageService) MarkRead(data *MarkReadStruct, instance *instance_model
 		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error validating message fields", instance.Id)
 		return "", errors.New("invalid phone number")
 	}
+
+	// Read receipts are RAW nodes (no usync) — strip the "+" so the receipt
+	// reaches the recipient. Same root cause as the typing fix above.
+	jid = utils.CanonicalJID(jid)
 
 	err = client.MarkRead(context.Background(), data.Id, time.Now(), jid, jid)
 	if err != nil {

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -141,6 +141,13 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 		return nil, errors.New("invalid phone number")
 	}
 
+	// Strip the "+" that ParseJID/CreateJID adds. The recipient is used both as
+	// the SendMessage target (usync/device resolution) AND as the MessageKey
+	// RemoteJID that references the reacted message's chat. A malformed "+JID"
+	// breaks device resolution (usync) and prevents the reaction from matching
+	// the original message's chat. See utils.CanonicalJID.
+	recipient = utils.CanonicalJID(recipient)
+
 	if data.Id == "" {
 		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Missing Id in Payload", instance.Id)
 		return nil, errors.New("missing id in payload")
@@ -166,7 +173,7 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 	if data.Participant != "" {
 		participantJID, ok := utils.ParseJID(data.Participant)
 		if ok {
-			messageKey.Participant = proto.String(participantJID.String())
+			messageKey.Participant = proto.String(utils.CanonicalJID(participantJID).String())
 		}
 	}
 

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -150,7 +150,8 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 		reaction = ""
 	}
 
-	// Create MessageKey
+	// Create MessageKey — msgId here is the ID of the message being reacted to,
+	// NOT the ID of the reaction message itself.
 	messageKey := &waCommon.MessageKey{
 		RemoteJID: proto.String(recipient.String()),
 		FromMe:    proto.Bool(fromMe),
@@ -167,16 +168,16 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 
 	msg := &waE2E.Message{
 		ReactionMessage: &waE2E.ReactionMessage{
-			Key:  messageKey,
-			Text: proto.String(reaction),
-			// GroupingKey:       proto.String(reaction),
+			Key:               messageKey,
+			Text:              proto.String(reaction),
 			SenderTimestampMS: proto.Int64(time.Now().UnixMilli()),
 		},
 	}
 
-	response, err := client.SendMessage(context.Background(), recipient, msg, whatsmeow.SendRequestExtra{
-		ID: msgId,
-	})
+	// Do NOT pass ID: msgId in SendRequestExtra — that would reuse the original
+	// message ID as the reaction envelope ID, causing WhatsApp to silently
+	// deduplicate and drop the reaction. Let whatsmeow generate a fresh ID.
+	response, err := client.SendMessage(context.Background(), recipient, msg)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +192,7 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 			IsFromMe: true,
 			IsGroup:  isGroup,
 		},
-		ID:        msgId,
+		ID:        response.ID,
 		Timestamp: time.Now(),
 		ServerID:  response.ServerID,
 		Type:      messageType,
@@ -225,12 +226,19 @@ func (m *messageService) ChatPresence(data *ChatPresenceStruct, instance *instan
 		media = "audio"
 	}
 
+	// Subscribe to the recipient's presence first.
+	// WhatsApp requires an active presence subscription before chat-state events
+	// (typing / recording indicators) are forwarded to the recipient by the servers.
+	if subErr := client.SubscribePresence(context.Background(), recipient); subErr != nil {
+		m.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] SubscribePresence for %s failed (non-fatal): %v", instance.Id, data.Number, subErr)
+	}
+
 	err = client.SendChatPresence(context.Background(), recipient, types.ChatPresence(data.State), types.ChatPresenceMedia(media))
 	if err != nil {
 		return "", err
 	}
 
-	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Message sent to %s", data.Number)
+	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Presence sent to %s", data.Number)
 
 	return ts.String(), nil
 }

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -150,8 +150,8 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 		reaction = ""
 	}
 
-	// Create MessageKey — msgId here is the ID of the message being reacted to,
-	// NOT the ID of the reaction message itself.
+	// Create MessageKey — msgId is the ID of the message being reacted to,
+	// NOT the ID of the reaction envelope itself.
 	messageKey := &waCommon.MessageKey{
 		RemoteJID: proto.String(recipient.String()),
 		FromMe:    proto.Bool(fromMe),
@@ -174,9 +174,10 @@ func (m *messageService) React(data *ReactStruct, instance *instance_model.Insta
 		},
 	}
 
-	// Do NOT pass ID: msgId in SendRequestExtra — that would reuse the original
-	// message ID as the reaction envelope ID, causing WhatsApp to silently
-	// deduplicate and drop the reaction. Let whatsmeow generate a fresh ID.
+	// Do NOT pass ID: msgId in SendRequestExtra. Doing so would reuse the
+	// original message ID as the reaction envelope ID; WhatsApp silently
+	// deduplicates it and drops the reaction. Let whatsmeow generate a
+	// fresh, unique ID for the envelope.
 	response, err := client.SendMessage(context.Background(), recipient, msg)
 	if err != nil {
 		return nil, err
@@ -226,19 +227,12 @@ func (m *messageService) ChatPresence(data *ChatPresenceStruct, instance *instan
 		media = "audio"
 	}
 
-	// Subscribe to the recipient's presence first.
-	// WhatsApp requires an active presence subscription before chat-state events
-	// (typing / recording indicators) are forwarded to the recipient by the servers.
-	if subErr := client.SubscribePresence(context.Background(), recipient); subErr != nil {
-		m.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] SubscribePresence for %s failed (non-fatal): %v", instance.Id, data.Number, subErr)
-	}
-
 	err = client.SendChatPresence(context.Background(), recipient, types.ChatPresence(data.State), types.ChatPresenceMedia(media))
 	if err != nil {
 		return "", err
 	}
 
-	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Presence sent to %s", data.Number)
+	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Message sent to %s", data.Number)
 
 	return ts.String(), nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -215,6 +215,21 @@ func ParseJID(arg string) (whatsmeow_types.JID, bool) {
 	return recipient, true
 }
 
+// CanonicalJID returns a JID safe for RAW protocol nodes (chatstate / typing,
+// read receipts, presence subscribe, etc.).
+//
+// CreateJID intentionally prefixes phone numbers with "+" (e.g.
+// "+554187083284@s.whatsapp.net") to match the IsOnWhatsApp/display convention.
+// Message sending tolerates this because whatsmeow normalizes the JID during
+// usync/device resolution. RAW nodes are sent WITHOUT usync, so a malformed
+// "+JID" reaches the server and the node is silently dropped (e.g. the "typing"
+// indicator never reaches the recipient). WhatsApp user JIDs are digits-only, so
+// strip the leading "+" to get the canonical form.
+func CanonicalJID(jid whatsmeow_types.JID) whatsmeow_types.JID {
+	jid.User = strings.TrimPrefix(jid.User, "+")
+	return jid
+}
+
 func CreateHTTPProxy(httpHost, httpPort, user, password string) (func(*http.Request) (*url.URL, error), error) {
 	address := fmt.Sprintf("http://%s:%s@%s:%s", user, password, httpHost, httpPort)
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -321,6 +322,64 @@ func TestParseJID(t *testing.T) {
 
 			if tt.expectOk && jid.String() != tt.expectJID {
 				t.Errorf("For input %q, expected JID %q, but got %q", tt.input, tt.expectJID, jid.String())
+			}
+		})
+	}
+}
+
+// TestCanonicalJID locks in the fix for the silent typing-indicator / receipt
+// drop: ParseJID (via CreateJID) prefixes phone numbers with "+", which is
+// tolerated by message sending (usync normalizes it) but breaks RAW nodes
+// (chatstate, read receipts). CanonicalJID must strip that "+" while leaving
+// already-canonical JIDs (LID, group, digits-only) untouched.
+func TestCanonicalJID(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedJID string // canonical JID expected after ParseJID -> CanonicalJID
+	}{
+		{
+			name:        "BR phone strips the leading +",
+			input:       "554187083284",
+			expectedJID: "554187083284@s.whatsapp.net",
+		},
+		{
+			name:        "US phone strips the leading +",
+			input:       "15551234567",
+			expectedJID: "15551234567@s.whatsapp.net",
+		},
+		{
+			name:        "Already-canonical JID is unchanged",
+			input:       "554187083284@s.whatsapp.net",
+			expectedJID: "554187083284@s.whatsapp.net",
+		},
+		{
+			name:        "LID JID is left untouched",
+			input:       "15883309207561@lid",
+			expectedJID: "15883309207561@lid",
+		},
+		{
+			name:        "Group JID is left untouched",
+			input:       "120363123456789012@g.us",
+			expectedJID: "120363123456789012@g.us",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jid, ok := ParseJID(tt.input)
+			if !ok {
+				t.Fatalf("ParseJID(%q) failed", tt.input)
+			}
+
+			canonical := CanonicalJID(jid)
+
+			if got := canonical.String(); got != tt.expectedJID {
+				t.Errorf("CanonicalJID for input %q = %q, want %q", tt.input, got, tt.expectedJID)
+			}
+
+			if strings.HasPrefix(canonical.User, "+") {
+				t.Errorf("CanonicalJID for input %q still has '+' in User: %q", tt.input, canonical.User)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #63

## What

Fix three WhatsApp features that returned `200` but never reached the recipient:

- **Typing** (`digitando...`) and **recording-audio** (`gravando áudio...`) on `POST /message/presence`
- **Reactions** on `POST /message/react`
- **Read receipts** on `POST /message/markread`

…plus a `delay` option to sustain the typing/recording indicator.

## Root cause

`utils.CreateJID`/`ParseJID` intentionally prefix phone numbers with `+` (e.g. `+5541...@s.whatsapp.net`) for the IsOnWhatsApp/display convention. **Message sending tolerates this** because whatsmeow normalizes the JID during usync/device resolution.

But several features send **RAW nodes without usync**, where the malformed `+JID` survives:

- **chatstate** (typing/recording) — the node went out with `to="+5541...@s.whatsapp.net"`, which WhatsApp does not route, so the indicator never appeared. Verified at the wire level.
- **reaction** — the `+JID` is used both as the `SendMessage` target (can stall device resolution → usync timeout) **and** as the `MessageKey.RemoteJID` that references the reacted message's chat; a `+`-prefixed chat doesn't match the real chat, so the reaction never attaches to the message.
- **read receipts** — same RAW-node issue.

## Changes

- **`utils.CanonicalJID`** — strips the leading `+` so RAW-node targets are canonical, digits-only WhatsApp JIDs. Covered by `TestCanonicalJID`.
- Apply it in **`ChatPresence`** (typing/recording), **`React`** (recipient + group participant) and **`MarkRead`** (read receipts).
- **`SendPresence(available)` before the chatstate** — WhatsApp only forwards chatstate while the sender is marked online; background presence handling can leave the client `Unavailable`, dropping the indicator.
- **`delay` (ms) on `/message/presence`** — keeps the indicator alive for the requested duration (re-sending every 5s, capped at 60s) then sends `paused`, instead of a single ephemeral fire.

## Testing

End-to-end on a live instance, confirmed on the recipient device:

- ✅ `digitando...` and `gravando áudio...` appear (and persist for `delay`).
- ✅ Reactions attach to the correct message, including multi-codepoint emoji (`❤️`), with no usync timeout.
- ✅ `go build`, `go vet`, `go test ./pkg/utils/` all green.

### Examples

```http
POST /message/presence
{ "number": "5541...", "state": "composing", "isAudio": false, "delay": 8000 }

POST /message/react
{ "number": "5541...", "id": "3EB0...", "reaction": "👍", "fromMe": true }
```

`isAudio: true` → `gravando áudio...`. `delay` omitted/0 → legacy single-fire (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)