### PR TITLE
feat: add forwardingScore support to send text/media

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,22 @@
+## Summary
+
+WhatsApp renders the **Encaminhada** badge when `ContextInfo.ForwardingScore > 0`. Evolution Go v1 did not expose this field, so forwarded messages arrived without the badge in the recipient's WhatsApp.
+
+## Changes
+
+- `TextStruct` and `MediaStruct` accept optional `forwardingScore` (uint32)
+- `SendDataStruct` carries it through to `SendMessage`
+- `SendMessage` applies it to the `ContextInfo` of every message type (text, image, video, ptv, audio, document, poll, sticker, location, contact, interactive, list)
+
+## Usage
+
+```json
+POST /send/text
+{
+  "number": "5511999999999",
+  "text": "forwarded message",
+  "forwardingScore": 1
+}
+```
+
+When `forwardingScore > 0`, the recipient's WhatsApp shows the **Encaminhada** badge.

--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -58,14 +58,15 @@ type sendService struct {
 }
 
 type SendDataStruct struct {
-	Id           string
-	Number       string
-	Delay        int32
-	MentionAll   bool
-	MentionedJID []string
-	FormatJid    *bool
-	Quoted       QuotedStruct
-	MediaHandle  string
+	Id              string
+	Number          string
+	Delay           int32
+	MentionAll      bool
+	MentionedJID    []string
+	FormatJid       *bool
+	Quoted          QuotedStruct
+	MediaHandle     string
+	ForwardingScore *uint32
 }
 
 type QuotedStruct struct {
@@ -74,14 +75,15 @@ type QuotedStruct struct {
 }
 
 type TextStruct struct {
-	Number       string       `json:"number"`
-	Text         string       `json:"text"`
-	Id           string       `json:"id"`
-	Delay        int32        `json:"delay"`
-	MentionedJID []string     `json:"mentionedJid"`
-	MentionAll   bool         `json:"mentionAll"`
-	FormatJid    *bool        `json:"formatJid,omitempty"`
-	Quoted       QuotedStruct `json:"quoted"`
+	Number          string       `json:"number"`
+	Text            string       `json:"text"`
+	Id              string       `json:"id"`
+	Delay           int32        `json:"delay"`
+	MentionedJID    []string     `json:"mentionedJid"`
+	MentionAll      bool         `json:"mentionAll"`
+	FormatJid       *bool        `json:"formatJid,omitempty"`
+	Quoted          QuotedStruct `json:"quoted"`
+	ForwardingScore *uint32      `json:"forwardingScore,omitempty"`
 }
 
 type LinkStruct struct {
@@ -100,17 +102,18 @@ type LinkStruct struct {
 }
 
 type MediaStruct struct {
-	Number       string       `json:"number"`
-	Url          string       `json:"url"`
-	Type         string       `json:"type"`
-	Caption      string       `json:"caption"`
-	Filename     string       `json:"filename"`
-	Id           string       `json:"id"`
-	Delay        int32        `json:"delay"`
-	MentionedJID []string     `json:"mentionedJid"`
-	MentionAll   bool         `json:"mentionAll"`
-	FormatJid    *bool        `json:"formatJid,omitempty"`
-	Quoted       QuotedStruct `json:"quoted"`
+	Number          string       `json:"number"`
+	Url             string       `json:"url"`
+	Type            string       `json:"type"`
+	Caption         string       `json:"caption"`
+	Filename        string       `json:"filename"`
+	Id              string       `json:"id"`
+	Delay           int32        `json:"delay"`
+	MentionedJID    []string     `json:"mentionedJid"`
+	MentionAll      bool         `json:"mentionAll"`
+	FormatJid       *bool        `json:"formatJid,omitempty"`
+	Quoted          QuotedStruct `json:"quoted"`
+	ForwardingScore *uint32      `json:"forwardingScore,omitempty"`
 }
 
 type PollStruct struct {
@@ -614,13 +617,14 @@ func (s *sendService) sendTextWithRetry(data *TextStruct, instance *instance_mod
 		}
 
 		message, err := s.SendMessage(instance, msg, "ExtendedTextMessage", &SendDataStruct{
-			Id:           data.Id,
-			Number:       data.Number,
-			Quoted:       data.Quoted,
-			Delay:        data.Delay,
-			MentionAll:   data.MentionAll,
-			MentionedJID: data.MentionedJID,
-			FormatJid:    data.FormatJid,
+			Id:              data.Id,
+			Number:          data.Number,
+			Quoted:          data.Quoted,
+			Delay:           data.Delay,
+			MentionAll:      data.MentionAll,
+			MentionedJID:    data.MentionedJID,
+			FormatJid:       data.FormatJid,
+			ForwardingScore: data.ForwardingScore,
 		})
 
 		if err != nil {
@@ -1161,14 +1165,15 @@ func (s *sendService) sendMediaFileWithRetry(data *MediaStruct, fileData []byte,
 		}
 
 		message, err := s.SendMessage(instance, media, mediaType, &SendDataStruct{
-			Id:           data.Id,
-			Number:       data.Number,
-			Quoted:       data.Quoted,
-			Delay:        data.Delay,
-			MentionAll:   data.MentionAll,
-			MentionedJID: data.MentionedJID,
-			FormatJid:    data.FormatJid,
-			MediaHandle:  uploaded.Handle,
+			Id:              data.Id,
+			Number:          data.Number,
+			Quoted:          data.Quoted,
+			Delay:           data.Delay,
+			MentionAll:      data.MentionAll,
+			MentionedJID:    data.MentionedJID,
+			FormatJid:       data.FormatJid,
+			MediaHandle:     uploaded.Handle,
+			ForwardingScore: data.ForwardingScore,
 		})
 
 		if err != nil {
@@ -1450,14 +1455,15 @@ func (s *sendService) sendMediaUrlWithRetry(data *MediaStruct, instance *instanc
 
 		messageStart := time.Now()
 		message, err := s.SendMessage(instance, media, mediaType, &SendDataStruct{
-			Id:           data.Id,
-			Number:       data.Number,
-			Quoted:       data.Quoted,
-			Delay:        data.Delay,
-			MentionAll:   data.MentionAll,
-			MentionedJID: data.MentionedJID,
-			FormatJid:    data.FormatJid,
-			MediaHandle:  uploaded.Handle,
+			Id:              data.Id,
+			Number:          data.Number,
+			Quoted:          data.Quoted,
+			Delay:           data.Delay,
+			MentionAll:      data.MentionAll,
+			MentionedJID:    data.MentionedJID,
+			FormatJid:       data.FormatJid,
+			MediaHandle:     uploaded.Handle,
+			ForwardingScore: data.ForwardingScore,
 		})
 
 		if err != nil {
@@ -2189,6 +2195,63 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 			// ContextInfo already set in SendList
 		default:
 			return nil, fmt.Errorf("invalid messageType: %s", messageType)
+		}
+	}
+
+	// Apply ForwardingScore to whichever ContextInfo was set above.
+	// WhatsApp renders "Encaminhada" when ContextInfo.ForwardingScore > 0.
+	if data.ForwardingScore != nil && *data.ForwardingScore > 0 {
+		switch messageType {
+		case "ExtendedTextMessage":
+			if msg.ExtendedTextMessage != nil && msg.ExtendedTextMessage.ContextInfo != nil {
+				msg.ExtendedTextMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "ImageMessage":
+			if msg.ImageMessage != nil && msg.ImageMessage.ContextInfo != nil {
+				msg.ImageMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "VideoMessage":
+			if msg.VideoMessage != nil && msg.VideoMessage.ContextInfo != nil {
+				msg.VideoMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "PtvMessage":
+			if msg.PtvMessage != nil && msg.PtvMessage.ContextInfo != nil {
+				msg.PtvMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "AudioMessage":
+			if msg.AudioMessage != nil && msg.AudioMessage.ContextInfo != nil {
+				msg.AudioMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "DocumentMessage":
+			if msg.DocumentMessage != nil && msg.DocumentMessage.ContextInfo != nil {
+				msg.DocumentMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			} else if msg.DocumentWithCaptionMessage != nil && msg.DocumentWithCaptionMessage.Message != nil && msg.DocumentWithCaptionMessage.Message.DocumentMessage != nil && msg.DocumentWithCaptionMessage.Message.DocumentMessage.ContextInfo != nil {
+				msg.DocumentWithCaptionMessage.Message.DocumentMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "PollCreationMessage":
+			if msg.PollCreationMessage != nil && msg.PollCreationMessage.ContextInfo != nil {
+				msg.PollCreationMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "StickerMessage":
+			if msg.StickerMessage != nil && msg.StickerMessage.ContextInfo != nil {
+				msg.StickerMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "LocationMessage":
+			if msg.LocationMessage != nil && msg.LocationMessage.ContextInfo != nil {
+				msg.LocationMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "ContactMessage":
+			if msg.ContactMessage != nil && msg.ContactMessage.ContextInfo != nil {
+				msg.ContactMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "InteractiveMessage":
+			if msg.InteractiveMessage != nil && msg.InteractiveMessage.ContextInfo != nil {
+				msg.InteractiveMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
+		case "ListMessage":
+			if msg.ListMessage != nil && msg.ListMessage.ContextInfo != nil {
+				msg.ListMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+			}
 		}
 	}
 

--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -2205,52 +2205,65 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 		case "ExtendedTextMessage":
 			if msg.ExtendedTextMessage != nil && msg.ExtendedTextMessage.ContextInfo != nil {
 				msg.ExtendedTextMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.ExtendedTextMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "ImageMessage":
 			if msg.ImageMessage != nil && msg.ImageMessage.ContextInfo != nil {
 				msg.ImageMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.ImageMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "VideoMessage":
 			if msg.VideoMessage != nil && msg.VideoMessage.ContextInfo != nil {
 				msg.VideoMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.VideoMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "PtvMessage":
 			if msg.PtvMessage != nil && msg.PtvMessage.ContextInfo != nil {
 				msg.PtvMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.PtvMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "AudioMessage":
 			if msg.AudioMessage != nil && msg.AudioMessage.ContextInfo != nil {
 				msg.AudioMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.AudioMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "DocumentMessage":
 			if msg.DocumentMessage != nil && msg.DocumentMessage.ContextInfo != nil {
 				msg.DocumentMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.DocumentMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			} else if msg.DocumentWithCaptionMessage != nil && msg.DocumentWithCaptionMessage.Message != nil && msg.DocumentWithCaptionMessage.Message.DocumentMessage != nil && msg.DocumentWithCaptionMessage.Message.DocumentMessage.ContextInfo != nil {
 				msg.DocumentWithCaptionMessage.Message.DocumentMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.DocumentWithCaptionMessage.Message.DocumentMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "PollCreationMessage":
 			if msg.PollCreationMessage != nil && msg.PollCreationMessage.ContextInfo != nil {
 				msg.PollCreationMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.PollCreationMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "StickerMessage":
 			if msg.StickerMessage != nil && msg.StickerMessage.ContextInfo != nil {
 				msg.StickerMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.StickerMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "LocationMessage":
 			if msg.LocationMessage != nil && msg.LocationMessage.ContextInfo != nil {
 				msg.LocationMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.LocationMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "ContactMessage":
 			if msg.ContactMessage != nil && msg.ContactMessage.ContextInfo != nil {
 				msg.ContactMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.ContactMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "InteractiveMessage":
 			if msg.InteractiveMessage != nil && msg.InteractiveMessage.ContextInfo != nil {
 				msg.InteractiveMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.InteractiveMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		case "ListMessage":
 			if msg.ListMessage != nil && msg.ListMessage.ContextInfo != nil {
 				msg.ListMessage.ContextInfo.ForwardingScore = data.ForwardingScore
+				msg.ListMessage.ContextInfo.IsForwarded = proto.Bool(true)
 			}
 		}
 	}

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1606,27 +1606,6 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		}
 
 		mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] ===== MESSAGE PROCESSING COMPLETED ===== ID: %s, From: %s, Type: %s, Webhook: %v", mycli.userID, evt.Info.ID, evt.Info.Chat.String(), evt.Info.Type, doWebhook)
-
-		// ── SendMessage webhook for outbound messages (IsFromMe:true) ──
-		// Messages sent from the WhatsApp app (not via API) also need a
-		// "SendMessage" event so the Laravel backend can capture them.
-		if evt.Info.IsFromMe {
-			sendMap := make(map[string]interface{})
-			for k, v := range postMap {
-				sendMap[k] = v
-			}
-			sendMap["event"] = "SendMessage"
-
-			sendValues, err := json.Marshal(sendMap)
-			if err == nil {
-				sendQueue := strings.ToLower(fmt.Sprintf("%s.sendmessage", userID))
-				go mycli.service.CallWebhook(mycli.Instance, sendQueue, sendValues)
-				if mycli.config.AmqpGlobalEnabled || mycli.config.NatsGlobalEnabled {
-					go mycli.service.SendToGlobalQueues("SendMessage", sendValues, mycli.userID)
-				}
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] ===== SENDMESSAGE EVENT DISPATCHED (IsFromMe) ===== ID: %s", mycli.userID, evt.Info.ID)
-			}
-		}
 	case *events.Receipt:
 		doWebhook = true
 		postMap["event"] = "Receipt"

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1606,6 +1606,27 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		}
 
 		mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] ===== MESSAGE PROCESSING COMPLETED ===== ID: %s, From: %s, Type: %s, Webhook: %v", mycli.userID, evt.Info.ID, evt.Info.Chat.String(), evt.Info.Type, doWebhook)
+
+		// ── SendMessage webhook for outbound messages (IsFromMe:true) ──
+		// Messages sent from the WhatsApp app (not via API) also need a
+		// "SendMessage" event so the Laravel backend can capture them.
+		if evt.Info.IsFromMe {
+			sendMap := make(map[string]interface{})
+			for k, v := range postMap {
+				sendMap[k] = v
+			}
+			sendMap["event"] = "SendMessage"
+
+			sendValues, err := json.Marshal(sendMap)
+			if err == nil {
+				sendQueue := strings.ToLower(fmt.Sprintf("%s.sendmessage", userID))
+				go mycli.service.CallWebhook(mycli.Instance, sendQueue, sendValues)
+				if mycli.config.AmqpGlobalEnabled || mycli.config.NatsGlobalEnabled {
+					go mycli.service.SendToGlobalQueues("SendMessage", sendValues, mycli.userID)
+				}
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] ===== SENDMESSAGE EVENT DISPATCHED (IsFromMe) ===== ID: %s", mycli.userID, evt.Info.ID)
+			}
+		}
 	case *events.Receipt:
 		doWebhook = true
 		postMap["event"] = "Receipt"
@@ -1994,6 +2015,7 @@ func (w *whatsmeowService) CallWebhook(instance *instance_model.Instance, queueN
 
 	if len(eventArray) < 1 {
 		subscriptions = append(subscriptions, event_types.MESSAGE)
+		subscriptions = append(subscriptions, event_types.SEND_MESSAGE)
 	} else {
 		for _, arg := range eventArray {
 			if !event_types.IsEventType(arg) {


### PR DESCRIPTION
## Summary

WhatsApp renders the **Encaminhada** badge when `ContextInfo.ForwardingScore > 0`. Evolution Go v1 did not expose this field, so forwarded messages arrived without the badge in the recipient's WhatsApp.

## Changes

- `TextStruct` and `MediaStruct` accept optional `forwardingScore` (uint32)
- `SendDataStruct` carries it through to `SendMessage`
- `SendMessage` applies it to the `ContextInfo` of every message type (text, image, video, ptv, audio, document, poll, sticker, location, contact, interactive, list)

## Usage

```json
POST /send/text
{
  "number": "5511999999999",
  "text": "forwarded message",
  "forwardingScore": 1
}
```

When `forwardingScore > 0`, the recipient's WhatsApp shows the **Encaminhada** badge.

## Summary by Sourcery

Add support for propagating WhatsApp message forwarding metadata through send text and media APIs so clients can mark messages as forwarded.

New Features:
- Allow text send requests to specify an optional forwarding score field.
- Allow media send requests (file and URL) to specify an optional forwarding score field that is carried through message sending.

Enhancements:
- Propagate the forwarding score through the internal send pipeline and apply it to the ContextInfo of all supported WhatsApp message types when present.