### PR TITLE
feat: implement alwaysOnline presence flag (was a no-op)

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -905,13 +905,28 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 
 			postMap["data"] = dataMap
 
-			go schedulePresenceUpdates(mycli)
+			// Respect the alwaysOnline instance flag. Previously the device was marked
+			// online unconditionally on every connect (and the periodic presence job was
+			// started), which kept the linked device permanently "available". WhatsApp then
+			// delivers messages to that active session and suppresses push notifications on
+			// the user's phone. When alwaysOnline is false we now send Unavailable instead.
+			var err error
+			if mycli.Instance.AlwaysOnline {
+				go schedulePresenceUpdates(mycli)
 
-			err := mycli.WAClient.SendPresence(context.Background(), types.PresenceAvailable)
-			if err != nil {
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Failed to send available presence %v", mycli.userID, err)
+				err = mycli.WAClient.SendPresence(context.Background(), types.PresenceAvailable)
+				if err != nil {
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Failed to send available presence %v", mycli.userID, err)
+				} else {
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Marked self as available", mycli.userID)
+				}
 			} else {
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Marked self as available", mycli.userID)
+				err = mycli.WAClient.SendPresence(context.Background(), types.PresenceUnavailable)
+				if err != nil {
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Failed to send unavailable presence %v", mycli.userID, err)
+				} else {
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Marked self as unavailable (alwaysOnline=false)", mycli.userID)
+				}
 			}
 
 			mycli.Instance.Connected = true


### PR DESCRIPTION
## Problem

Numbers connected through Evolution Go **stop receiving push notifications on the phone**. This happens regardless of the `alwaysOnline` advanced setting — even with `alwaysOnline=false` for every instance.

## Root cause

The `alwaysOnline` setting exists on the instance model, the REST API and Swagger (the CHANGELOG even notes `alwaysOnline (still to be implemented)`), but it was **never wired into the presence logic**.

In `pkg/whatsmeow/service/whatsmeow.go`, on the `events.Connected` handler, the client:
1. calls `SendPresence(types.PresenceAvailable)` **unconditionally** on every (re)connect, and
2. starts `schedulePresenceUpdates`, which every 1–3h toggles `Unavailable` → `Available`.

Since whatsmeow reconnects frequently, the linked device is kept **permanently "available"**. WhatsApp then delivers messages to that active companion session and **suppresses push notifications on the primary phone**.

## Fix

Gate the connect-time presence (and the periodic `schedulePresenceUpdates` job) behind `Instance.AlwaysOnline`:

- `alwaysOnline == true` → previous behavior (mark available + start the periodic job).
- `alwaysOnline == false` → send `PresenceUnavailable` once, so the phone keeps receiving push notifications.

This makes the existing panel/API toggle actually work, per-instance, with no breaking change to current setups (the flag defaults to `false` in the model — operators who relied on always-online can simply enable it).

## Testing

Built and deployed on a production VPS (upgraded from 0.6.1 to 0.7.1 + this patch) across 16 instances. After the change:
- logs show `Marked self as unavailable (alwaysOnline=false)` on connect instead of `Marked self as available`;
- sessions persisted (no re-pairing);
- inbound/outbound messages and webhooks unaffected;
- push notifications confirmed back on the users' phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Respect the instance alwaysOnline flag when setting WhatsApp presence on connect so linked devices are not kept permanently available by default.

Bug Fixes:
- Fix presence handling so instances with alwaysOnline disabled are marked unavailable instead of always being set to available on connect, restoring push notifications to primary phones.

Enhancements:
- Add conditional scheduling of periodic presence updates and improved logging for available/unavailable presence changes based on the alwaysOnline flag.