### PR TITLE
feat(events): forward Picture, UserAbout and BusinessName webhook events

### DIFF
--- a/pkg/internal/event_types/event_types.go
+++ b/pkg/internal/event_types/event_types.go
@@ -16,6 +16,9 @@ const (
 	NEWSLETTER    = "NEWSLETTER"
 	QRCODE        = "QRCODE"
 	BUTTON_CLICK  = "BUTTON_CLICK"
+	PICTURE       = "PICTURE"
+	USER_ABOUT    = "USER_ABOUT"
+	BUSINESS_NAME = "BUSINESS_NAME"
 )
 
 var AllEventTypes = []string{
@@ -33,6 +36,9 @@ var AllEventTypes = []string{
 	NEWSLETTER,
 	QRCODE,
 	BUTTON_CLICK,
+	PICTURE,
+	USER_ABOUT,
+	BUSINESS_NAME,
 }
 
 var validEventTypes = map[string]bool{
@@ -51,6 +57,9 @@ var validEventTypes = map[string]bool{
 	NEWSLETTER:    true,
 	QRCODE:        true,
 	BUTTON_CLICK:  true,
+	PICTURE:       true,
+	USER_ABOUT:    true,
+	BUSINESS_NAME: true,
 }
 
 func IsEventType(eventType string) bool {

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1898,6 +1898,15 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 	case *events.PushName:
 		doWebhook = true
 		postMap["event"] = "PushName"
+	case *events.Picture:
+		doWebhook = true
+		postMap["event"] = "Picture"
+	case *events.UserAbout:
+		doWebhook = true
+		postMap["event"] = "UserAbout"
+	case *events.BusinessName:
+		doWebhook = true
+		postMap["event"] = "BusinessName"
 	case *events.IdentityChange:
 		doWebhook = false
 	case *events.GroupInfo:
@@ -2124,6 +2133,21 @@ func (w *whatsmeowService) CallWebhook(instance *instance_model.Instance, queueN
 		}
 	case "ButtonClick":
 		if contains(subscriptions, "BUTTON_CLICK") || contains(subscriptions, "MESSAGE") {
+			w.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Event received of type %s", instance.Id, eventType)
+			w.sendToQueueOrWebhook(instance, queueName, jsonData)
+		}
+	case "Picture":
+		if contains(subscriptions, "PICTURE") {
+			w.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Event received of type %s", instance.Id, eventType)
+			w.sendToQueueOrWebhook(instance, queueName, jsonData)
+		}
+	case "UserAbout":
+		if contains(subscriptions, "USER_ABOUT") {
+			w.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Event received of type %s", instance.Id, eventType)
+			w.sendToQueueOrWebhook(instance, queueName, jsonData)
+		}
+	case "BusinessName":
+		if contains(subscriptions, "BUSINESS_NAME") {
 			w.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Event received of type %s", instance.Id, eventType)
 			w.sendToQueueOrWebhook(instance, queueName, jsonData)
 		}


### PR DESCRIPTION
## Description

Three whatsmeow events emitted by `go.mau.fi/whatsmeow` are silently dropped by the dispatcher in `pkg/whatsmeow/service/whatsmeow.go` because the central switch has no case for them. They only surface in stdout as `Unhandled event *events.X` and never reach consumers.

This adds the three missing handlers plus the matching subscribe categories so they can be received via webhook / queue / websocket. It mirrors the existing `*events.PushName` handling for the three new events.

### Events

| Event | Source | Fires when |
|---|---|---|
| `*events.Picture` | `types/events/events.go` | A user's profile picture or a group's photo changes. Fields: `JID`, `Author`, `Timestamp`, `Remove`, `PictureID`. |
| `*events.UserAbout` | `types/events/events.go` | A user's about/status text changes. Fields: `JID`, `Status`, `Timestamp`. |
| `*events.BusinessName` | `types/events/appstate.go` | A contact's verified business name changes, lazily on inbound messages. Fields: `JID`, `OldBusinessName`, `NewBusinessName`. |

### Changes

1. `pkg/whatsmeow/service/whatsmeow.go` (`myEventHandler`): three new cases mirroring the existing `*events.Contact` / `*events.PushName` handlers. They set `doWebhook = true` and `postMap["event"]`; the raw event is already attached via `postMap["data"] = rawEvt`.
2. `pkg/whatsmeow/service/whatsmeow.go` (`CallWebhook`): three new branches so consumers can subscribe to `PICTURE` / `USER_ABOUT` / `BUSINESS_NAME` independently, following the existing per-category split (e.g. `MESSAGE` vs `SEND_MESSAGE` vs `READ_RECEIPT`).
3. `pkg/internal/event_types/event_types.go`: the three new constants in the const block, in `AllEventTypes`, and in `validEventTypes` so `IsEventType` accepts them.

The change is additive: existing subscribers keep receiving exactly what they did before. Consumers wanting the new events opt in by including `PICTURE` / `USER_ABOUT` / `BUSINESS_NAME` (or `ALL`) in their subscribe list.

### Use cases

- `Picture`: keep a CRM avatar cache in sync in real time instead of polling `/chat/fetchProfilePictureUrl/{instance}` per contact, which has no batch endpoint and risks rate-flagging on large sweeps.
- `UserAbout`: surface each contact's status text in contact cards / chat lists without polling.
- `BusinessName`: reflect a contact's verified business name after they edit it on their phone. Today the only signal is the `Connected` re-emit, which carries the user's own `pushName`, not the contact's verified business name.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- `go build ./...` passes against `develop` (whatsmeow-lib pinned at `0923702`).
- `go vet` is clean on the two touched packages.
- Additive only: no behavior change to existing events; the new events require explicit opt-in.

## Notes

Reopened against `develop` (previously evolution-foundation/evolution-go#57, which targeted `main`).

## Summary by Sourcery

Forward additional whatsmeow profile-related events to downstream consumers via existing webhook/queue mechanisms.

New Features:
- Expose Picture, UserAbout, and BusinessName events through the generic event handler so they can be delivered over webhooks, queues, and websockets.
- Allow clients to subscribe specifically to PICTURE, USER_ABOUT, and BUSINESS_NAME event categories via CallWebhook routing.
- Recognize PICTURE, USER_ABOUT, and BUSINESS_NAME as valid event types in the shared event type registry.