### PR TITLE
feat(message): add POST /message/markplayed endpoint (played receipt / blue mic)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1944,6 +1944,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/message/markplayed": {
+            "post": {
+                "description": "Mark an audio message as played",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Mark an audio message as played",
+                "parameters": [
+                    {
+                        "description": "Mark an audio message as played",
+                        "name": "message",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkPlayedStruct"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "400": {
+                        "description": "Error on validation",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
         "/message/markread": {
             "post": {
                 "description": "Mark a message as read",
@@ -3845,6 +3891,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "messageId": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkPlayedStruct": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "number": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1936,6 +1936,52 @@
                 }
             }
         },
+        "/message/markplayed": {
+            "post": {
+                "description": "Mark an audio message as played",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Message"
+                ],
+                "summary": "Mark an audio message as played",
+                "parameters": [
+                    {
+                        "description": "Mark an audio message as played",
+                        "name": "message",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkPlayedStruct"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "success",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "400": {
+                        "description": "Error on validation",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    }
+                }
+            }
+        },
         "/message/markread": {
             "post": {
                 "description": "Mark a message as read",
@@ -3837,6 +3883,20 @@
                     "type": "string"
                 },
                 "messageId": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkPlayedStruct": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "number": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -234,6 +234,15 @@ definitions:
       messageId:
         type: string
     type: object
+  github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkPlayedStruct:
+    properties:
+      id:
+        items:
+          type: string
+        type: array
+      number:
+        type: string
+    type: object
   github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkReadStruct:
     properties:
       id:
@@ -7868,6 +7877,36 @@ paths:
           schema:
             $ref: '#/definitions/gin.H'
       summary: Edit a message
+      tags:
+      - Message
+  /message/markplayed:
+    post:
+      consumes:
+      - application/json
+      description: Mark an audio message as played
+      parameters:
+      - description: Mark an audio message as played
+        in: body
+        name: message
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_EvolutionAPI_evolution-go_pkg_message_service.MarkPlayedStruct'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: success
+          schema:
+            $ref: '#/definitions/gin.H'
+        "400":
+          description: Error on validation
+          schema:
+            $ref: '#/definitions/gin.H'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/gin.H'
+      summary: Mark an audio message as played
       tags:
       - Message
   /message/markread:

--- a/pkg/message/handler/message_handler.go
+++ b/pkg/message/handler/message_handler.go
@@ -12,6 +12,7 @@ type MessageHandler interface {
 	React(ctx *gin.Context)
 	ChatPresence(ctx *gin.Context)
 	MarkRead(ctx *gin.Context)
+	MarkPlayed(ctx *gin.Context)
 	DownloadMedia(ctx *gin.Context)
 	GetMessageStatus(ctx *gin.Context)
 	DeleteMessageEveryone(ctx *gin.Context)
@@ -156,6 +157,56 @@ func (m *messageHandler) MarkRead(ctx *gin.Context) {
 	}
 
 	ts, err := m.messageService.MarkRead(data, instance)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	responseData := gin.H{
+		"timestamp": ts,
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "success", "data": responseData})
+}
+
+// MarkPlayed mark an audio message as played (blue mic icon)
+// @Summary Mark an audio message as played
+// @Description Mark an audio message as played
+// @Tags Message
+// @Accept json
+// @Produce json
+// @Param message body message_service.MarkPlayedStruct true "Mark an audio message as played"
+// @Success 200 {object} gin.H "success"
+// @Failure 400 {object} gin.H "Error on validation"
+// @Failure 500 {object} gin.H "Internal server error"
+// @Router /message/markplayed [post]
+func (m *messageHandler) MarkPlayed(ctx *gin.Context) {
+	getInstance := ctx.MustGet("instance")
+
+	instance, ok := getInstance.(*instance_model.Instance)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "instance not found"})
+		return
+	}
+
+	var data *message_service.MarkPlayedStruct
+	err := ctx.ShouldBindBodyWithJSON(&data)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if data.Number == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "phone number is required"})
+		return
+	}
+
+	if len(data.Id) < 1 {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+
+	ts, err := m.messageService.MarkPlayed(data, instance)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -27,6 +27,7 @@ type MessageService interface {
 	React(data *ReactStruct, instance *instance_model.Instance) (*MessageSendStruct, error)
 	ChatPresence(data *ChatPresenceStruct, instance *instance_model.Instance) (string, error)
 	MarkRead(data *MarkReadStruct, instance *instance_model.Instance) (string, error)
+	MarkPlayed(data *MarkPlayedStruct, instance *instance_model.Instance) (string, error)
 	DownloadMedia(data *DownloadMediaStruct, instance *instance_model.Instance, request *http.Request) (*dataurl.DataURL, string, error)
 	GetMessageStatus(data *MessageStatusStruct, instance *instance_model.Instance) (*message_model.Message, string, error)
 	DeleteMessageEveryone(data *MessageStruct, instance *instance_model.Instance) (string, string, error)
@@ -55,6 +56,11 @@ type ChatPresenceStruct struct {
 }
 
 type MarkReadStruct struct {
+	Id     []string `json:"id"`
+	Number string   `json:"number"`
+}
+
+type MarkPlayedStruct struct {
 	Id     []string `json:"id"`
 	Number string   `json:"number"`
 }
@@ -253,6 +259,29 @@ func (m *messageService) MarkRead(data *MarkReadStruct, instance *instance_model
 	if err != nil {
 		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] error marking message as read: %v", instance.Id, err)
 		return "", errors.New("error marking message as read")
+	}
+
+	return ts.String(), nil
+}
+
+func (m *messageService) MarkPlayed(data *MarkPlayedStruct, instance *instance_model.Instance) (string, error) {
+	client, err := m.ensureClientConnected(instance.Id)
+	if err != nil {
+		return "", err
+	}
+
+	var ts time.Time
+
+	jid, ok := utils.ParseJID(data.Number)
+	if !ok {
+		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error validating message fields", instance.Id)
+		return "", errors.New("invalid phone number")
+	}
+
+	err = client.MarkRead(context.Background(), data.Id, time.Now(), jid, jid, types.ReceiptTypePlayed)
+	if err != nil {
+		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] error marking message as played: %v", instance.Id, err)
+		return "", errors.New("error marking message as played")
 	}
 
 	return ts.String(), nil

--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -151,6 +151,7 @@ func (r *Routes) AssignRoutes(eng *gin.Engine) {
 			routes.POST("/react", r.jidValidationMiddleware.ValidateJIDFields("number"), r.messageHandler.React)
 			routes.POST("/presence", r.jidValidationMiddleware.ValidateNumberField(), r.messageHandler.ChatPresence)
 			routes.POST("/markread", r.jidValidationMiddleware.ValidateNumberField(), r.messageHandler.MarkRead)
+			routes.POST("/markplayed", r.jidValidationMiddleware.ValidateNumberField(), r.messageHandler.MarkPlayed)
 			routes.POST("/downloadmedia", r.messageHandler.DownloadMedia)
 			routes.POST("/status", r.messageHandler.GetMessageStatus)
 			routes.POST("/delete", r.jidValidationMiddleware.ValidateNumberField(), r.messageHandler.DeleteMessageEveryone)


### PR DESCRIPTION
## O que

Adiciona o endpoint `POST /message/markplayed` — marca uma mensagem de áudio como reproduzida (mic azul / played receipt), via `client.MarkRead(..., types.ReceiptTypePlayed)`.

Segue exatamente o padrão do `MarkRead` existente:
- `pkg/message/service/message_service.go` — `MarkPlayedStruct{Id []string, Number string}` + `MarkPlayed(...)`
- `pkg/message/handler/message_handler.go` — handler `MarkPlayed` (valida `number` + `id`)
- `pkg/routes/routes.go` — `POST /markplayed` com `ValidateNumberField()`
- `docs/*` — swagger regenerado **apenas** para este endpoint

## Por que esta PR substitui a #46

A #46 apontava pra `main` a partir de uma base desatualizada e arrastava ~56 arquivos de ruído (rename da org, sync de submódulos, bundles do manager, drift de swagger). Esta PR é a **mesma mudança isolada** rebaseada em cima de `develop`, conforme review do @NeritonDias: **6 arquivos, +240/−0** (81 de código + 159 de swagger, só markplayed — sem o drift de outros endpoints).