### PR TITLE
fix(whatsmeow): reuse a single capped sqlstore container (fix connection leak)

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -301,6 +301,53 @@ func (w whatsmeowService) ForceUpdateJid(instanceId string, number string) error
 	return nil
 }
 
+// --- PATCH leak-fix (#269): container/pool UNICO e capado pro store do whatsmeow ---
+// Antes, cada StartClient (conectar E cada reconexao) chamava sqlstore.New(), abrindo
+// um *sql.DB novo sem cap e nunca fechado -> leak que saturava o Postgres do evogo_auth.
+// Agora e um container compartilhado, criado uma vez, com pool limitado e conexao direta.
+var (
+	sharedAuthContainer     *sqlstore.Container
+	sharedAuthContainerErr  error
+	sharedAuthContainerOnce sync.Once
+)
+
+func (w whatsmeowService) getAuthContainer() (*sqlstore.Container, error) {
+	sharedAuthContainerOnce.Do(func() {
+		var dbLog waLog.Logger
+		if w.config.WaDebug != "" {
+			dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+		}
+		var dialect, address string
+		if w.config.PostgresAuthDB != "" {
+			dialect, address = "postgres", w.config.PostgresAuthDB
+		} else {
+			dialect = "sqlite"
+			address = fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+		}
+		db, err := sql.Open(dialect, address)
+		if err != nil {
+			sharedAuthContainerErr = fmt.Errorf("failed to open auth database: %w", err)
+			return
+		}
+		if dialect == "postgres" {
+			db.SetMaxOpenConns(20)
+			db.SetMaxIdleConns(5)
+			db.SetConnMaxLifetime(5 * time.Minute)
+			db.SetConnMaxIdleTime(2 * time.Minute)
+		} else {
+			db.SetMaxOpenConns(1)
+		}
+		container := sqlstore.NewWithDB(db, dialect, dbLog)
+		if err := container.Upgrade(context.Background()); err != nil {
+			_ = db.Close()
+			sharedAuthContainerErr = fmt.Errorf("failed to upgrade auth database: %w", err)
+			return
+		}
+		sharedAuthContainer = container
+	})
+	return sharedAuthContainer, sharedAuthContainerErr
+}
+
 func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("Starting websocket connection to Whatsapp for user '%s'", cd.Instance.Id)
@@ -315,26 +362,9 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	}
 
 	var container *sqlstore.Container
-
-	if w.config.WaDebug != "" {
-		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
-		}
-	} else {
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)
-		}
-	}
-
+	container, err = w.getAuthContainer()
 	if err != nil {
-		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to create container: %v", cd.Instance.Id, err)
+		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to get auth container: %v", cd.Instance.Id, err)
 		return
 	}
 


### PR DESCRIPTION
## Problem

`StartClient()` (`pkg/whatsmeow/service/whatsmeow.go`) calls `sqlstore.New()` on **every** connect and **every** reconnect. Each call opens a fresh `*sql.DB` with the Go defaults `MaxOpenConns=0` (unlimited) and `ConnMaxLifetime=0` (never expires), and the resulting `*sqlstore.Container` is never closed.

In a deployment with several instances reconnecting (QR expiry, network blips, `CONNECT_ON_STARTUP=true`), this leaks one connection pool per attempt. We hit `FATAL: sorry, too many clients already` on Postgres with ~99 idle leaked connections, after which **no new instance could connect**.

## Fix

Create the whatsmeow auth-store container **once** (guarded by `sync.Once`) using `sqlstore.NewWithDB()` on a `*sql.DB` with a bounded pool (`SetMaxOpenConns`, `SetMaxIdleConns`, `SetConnMaxLifetime`, `SetConnMaxIdleTime`), and reuse it across all `StartClient()` calls. whatsmeow's container is explicitly designed to hold multiple devices, so a single shared container is the intended pattern.

- Postgres backend connections capped at ~20 regardless of instance count (was unbounded).
- No behavior change to pairing/connection — the store is still a direct DB connection.
- SQLite path preserved (single shared container, `MaxOpenConns=1`).

## Testing

- Builds clean (CGO enabled, `golang:1.25`).
- In our production deployment, Postgres went from **100/100 saturated → ~2–5 connections** with all instances reconnecting normally from their persisted sessions (no re-pairing).

Single-file change in `StartClient()` + a small `sync.Once` helper.

## Summary by Sourcery

Reuse a single shared, bounded whatsmeow SQL auth-store container across all client starts and reconnects to prevent database connection leaks and pool exhaustion.

Bug Fixes:
- Fix leaking of auth-store database connections by avoiding per-StartClient sqlstore containers that were never closed.

Enhancements:
- Introduce a shared, lazily-initialized auth-store container backed by a capped *sql.DB connection pool for Postgres and a single-connection pool for SQLite.