### PR TITLE
fix(whatsmeow): reuse a single capped sqlstore container (fixes Postgres connection leak)

### DIFF
--- a/pkg/whatsmeow/service/auth_container_retry_test.go
+++ b/pkg/whatsmeow/service/auth_container_retry_test.go
@@ -29,6 +29,13 @@ func TestGetAuthContainerRetryAndReuse(t *testing.T) {
 	if _, err := bad.getAuthContainer(); err == nil {
 		t.Fatal("esperava erro com diretório inexistente, veio nil")
 	}
+	// Falha não deve ser memorizada no singleton
+	sharedAuthContainerMu.Lock()
+	if sharedAuthContainer != nil {
+		sharedAuthContainerMu.Unlock()
+		t.Fatalf("failed container should not be memoized (sharedAuthContainer = %#v)", sharedAuthContainer)
+	}
+	sharedAuthContainerMu.Unlock()
 
 	// Sucesso: exPath válido com o subdiretório dbdata esperado pelo DSN.
 	goodPath := t.TempDir()

--- a/pkg/whatsmeow/service/auth_container_retry_test.go
+++ b/pkg/whatsmeow/service/auth_container_retry_test.go
@@ -1,0 +1,57 @@
+package whatsmeow_service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/EvolutionAPI/evolution-go/pkg/config"
+)
+
+// Valida a semântica do getAuthContainer compartilhado, usando o caminho SQLite
+// (auto-contido, sem serviço externo — roda em qualquer CI):
+//  1. falha na criação NÃO é memorizada (retry possível em vez de erro cacheado pra sempre)
+//  2. sucesso é memorizado e o MESMO container é reusado nas chamadas seguintes
+func TestGetAuthContainerRetryAndReuse(t *testing.T) {
+	// estado limpo do singleton
+	sharedAuthContainerMu.Lock()
+	sharedAuthContainer = nil
+	sharedAuthContainerMu.Unlock()
+
+	// Falha: exPath aponta pra diretório inexistente — o SQLite não cria
+	// diretórios intermediários, então o Upgrade falha na primeira conexão.
+	bad := whatsmeowService{
+		config: &config.Config{},
+		exPath: filepath.Join(t.TempDir(), "does-not-exist"),
+	}
+	if _, err := bad.getAuthContainer(); err == nil {
+		t.Fatal("esperava erro com diretório inexistente, veio nil")
+	}
+
+	// Sucesso: exPath válido com o subdiretório dbdata esperado pelo DSN.
+	goodPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(goodPath, "dbdata"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	good := whatsmeowService{
+		config: &config.Config{},
+		exPath: goodPath,
+	}
+	c1, err := good.getAuthContainer()
+	if err != nil {
+		t.Fatalf("retry após falha deveria funcionar em vez de devolver erro cacheado: %v", err)
+	}
+	if c1 == nil {
+		t.Fatal("container nil após sucesso")
+	}
+
+	c2, err := good.getAuthContainer()
+	if err != nil {
+		t.Fatalf("segunda chamada falhou: %v", err)
+	}
+	if c1 != c2 {
+		t.Fatal("container não foi reusado — deveria ser singleton compartilhado")
+	}
+}

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -279,51 +279,55 @@ func (w whatsmeowService) ForceUpdateJid(instanceId string, number string) error
 	return nil
 }
 
-// --- PATCH leak-fix (#269): container/pool UNICO e capado pro store do whatsmeow ---
+// Container/pool unico e capado pro store do whatsmeow.
 // Antes, cada StartClient (conectar E cada reconexao) chamava sqlstore.New(), abrindo
 // um *sql.DB novo sem cap e nunca fechado -> leak que saturava o Postgres do evogo_auth.
-// Agora e um container compartilhado, criado uma vez, com pool limitado e conexao direta.
+// Agora e um container compartilhado, com pool limitado e conexao direta.
+// Somente o sucesso e memorizado: se a criacao falhar (ex.: Postgres indisponivel
+// no boot), a proxima chamada tenta de novo em vez de devolver o erro pra sempre.
 var (
-	sharedAuthContainer     *sqlstore.Container
-	sharedAuthContainerErr  error
-	sharedAuthContainerOnce sync.Once
+	sharedAuthContainer   *sqlstore.Container
+	sharedAuthContainerMu sync.Mutex
 )
 
 func (w whatsmeowService) getAuthContainer() (*sqlstore.Container, error) {
-	sharedAuthContainerOnce.Do(func() {
-		var dbLog waLog.Logger
-		if w.config.WaDebug != "" {
-			dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
-		}
-		var dialect, address string
-		if w.config.PostgresAuthDB != "" {
-			dialect, address = "postgres", w.config.PostgresAuthDB
-		} else {
-			dialect = "sqlite"
-			address = fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-		}
-		db, err := sql.Open(dialect, address)
-		if err != nil {
-			sharedAuthContainerErr = fmt.Errorf("failed to open auth database: %w", err)
-			return
-		}
-		if dialect == "postgres" {
-			db.SetMaxOpenConns(20)
-			db.SetMaxIdleConns(5)
-			db.SetConnMaxLifetime(5 * time.Minute)
-			db.SetConnMaxIdleTime(2 * time.Minute)
-		} else {
-			db.SetMaxOpenConns(1)
-		}
-		container := sqlstore.NewWithDB(db, dialect, dbLog)
-		if err := container.Upgrade(context.Background()); err != nil {
-			_ = db.Close()
-			sharedAuthContainerErr = fmt.Errorf("failed to upgrade auth database: %w", err)
-			return
-		}
-		sharedAuthContainer = container
-	})
-	return sharedAuthContainer, sharedAuthContainerErr
+	sharedAuthContainerMu.Lock()
+	defer sharedAuthContainerMu.Unlock()
+
+	if sharedAuthContainer != nil {
+		return sharedAuthContainer, nil
+	}
+
+	var dbLog waLog.Logger
+	if w.config.WaDebug != "" {
+		dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+	}
+	var dialect, address string
+	if w.config.PostgresAuthDB != "" {
+		dialect, address = "postgres", w.config.PostgresAuthDB
+	} else {
+		dialect = "sqlite"
+		address = fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+	}
+	db, err := sql.Open(dialect, address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open auth database: %w", err)
+	}
+	if dialect == "postgres" {
+		db.SetMaxOpenConns(20)
+		db.SetMaxIdleConns(5)
+		db.SetConnMaxLifetime(5 * time.Minute)
+		db.SetConnMaxIdleTime(2 * time.Minute)
+	} else {
+		db.SetMaxOpenConns(1)
+	}
+	container := sqlstore.NewWithDB(db, dialect, dbLog)
+	if err := container.Upgrade(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("failed to upgrade auth database: %w", err)
+	}
+	sharedAuthContainer = container
+	return sharedAuthContainer, nil
 }
 
 func (w whatsmeowService) StartClient(cd *ClientData) {

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -279,6 +279,53 @@ func (w whatsmeowService) ForceUpdateJid(instanceId string, number string) error
 	return nil
 }
 
+// --- PATCH leak-fix (#269): container/pool UNICO e capado pro store do whatsmeow ---
+// Antes, cada StartClient (conectar E cada reconexao) chamava sqlstore.New(), abrindo
+// um *sql.DB novo sem cap e nunca fechado -> leak que saturava o Postgres do evogo_auth.
+// Agora e um container compartilhado, criado uma vez, com pool limitado e conexao direta.
+var (
+	sharedAuthContainer     *sqlstore.Container
+	sharedAuthContainerErr  error
+	sharedAuthContainerOnce sync.Once
+)
+
+func (w whatsmeowService) getAuthContainer() (*sqlstore.Container, error) {
+	sharedAuthContainerOnce.Do(func() {
+		var dbLog waLog.Logger
+		if w.config.WaDebug != "" {
+			dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+		}
+		var dialect, address string
+		if w.config.PostgresAuthDB != "" {
+			dialect, address = "postgres", w.config.PostgresAuthDB
+		} else {
+			dialect = "sqlite"
+			address = fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+		}
+		db, err := sql.Open(dialect, address)
+		if err != nil {
+			sharedAuthContainerErr = fmt.Errorf("failed to open auth database: %w", err)
+			return
+		}
+		if dialect == "postgres" {
+			db.SetMaxOpenConns(20)
+			db.SetMaxIdleConns(5)
+			db.SetConnMaxLifetime(5 * time.Minute)
+			db.SetConnMaxIdleTime(2 * time.Minute)
+		} else {
+			db.SetMaxOpenConns(1)
+		}
+		container := sqlstore.NewWithDB(db, dialect, dbLog)
+		if err := container.Upgrade(context.Background()); err != nil {
+			_ = db.Close()
+			sharedAuthContainerErr = fmt.Errorf("failed to upgrade auth database: %w", err)
+			return
+		}
+		sharedAuthContainer = container
+	})
+	return sharedAuthContainer, sharedAuthContainerErr
+}
+
 func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("Starting websocket connection to Whatsapp for user '%s'", cd.Instance.Id)
@@ -293,26 +340,9 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	}
 
 	var container *sqlstore.Container
-
-	if w.config.WaDebug != "" {
-		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
-		}
-	} else {
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)
-		}
-	}
-
+	container, err = w.getAuthContainer()
 	if err != nil {
-		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to create container: %v", cd.Instance.Id, err)
+		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to get auth container: %v", cd.Instance.Id, err)
 		return
 	}
 


### PR DESCRIPTION
## Description

  `StartClient()` called `sqlstore.New()` on **every** connect and **every** reconnect. Each call opens a fresh `*sql.DB` with unbounded defaults
  (`MaxOpenConns=0`, `ConnMaxLifetime=0`) and the resulting `*sqlstore.Container` is never closed. Instances stuck in QR-expiry/reconnect loops leak one
  connection pool per attempt until Postgres hits `FATAL: sorry, too many clients already`, after which no instance can connect.

  This PR supersedes #102 by @Ay0rus, which targeted `main` — the same fix is rebased onto `develop` (applied cleanly, original authorship preserved in the
  first commit), plus a hardening of the initialization path:

  - **Commit 1 (@Ay0rus):** shared, lazily-created `sqlstore.Container` with a capped pool (Postgres: 20 max open / 5 idle / 5min lifetime / 2min idle;
  SQLite: single connection), reused across all `StartClient()` calls — whatsmeow's container is designed to hold multiple devices.
  - **Commit 2:** replaces the original `sync.Once` with a mutex that memoizes **only success**. With `sync.Once`, a Postgres hiccup during the first
  `StartClient` cached the error forever, leaving the service unable to connect until a process restart. Now failures retry on the next call.

  Reproduced locally before the fix: 15 calls to `/instance/reconnect` took `evogo_auth` from 1 to 16 connections, growing unbounded afterwards (reached 32+
  within minutes via the internal QR-expiry restart loop). With the fix, the same procedure stays at 1-2 connections.

  ## Related Issue

  Closes #106, closes #109, closes #112

  Supersedes #102 (same fix, retargeted at develop as requested, original commit authorship preserved)

  ## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring (no functional changes)
  - [x] Performance improvement

  ## Testing
  - [x] Manual testing completed
  - [x] Functionality verified in development environment
  - [x] No breaking changes introduced

  Includes a self-contained regression test (`auth_container_retry_test.go`) using the SQLite path — no external services required, verified in a clean
  `golang:1.25` container. It asserts that (1) a failed container creation is **not** cached, (2) the next call retries and succeeds, and (3) subsequent calls
  return the same shared container instance.

  Manual verification against a local Postgres:

  | Scenario | Connections on `evogo_auth` |
  |---|---|
  | Before fix — 15× `/instance/reconnect` | 1 → 16 (unbounded growth afterwards) |
  | After fix — same procedure | stays at 1-2 |

  ## Screenshots (if applicable)

  N/A

  ## Checklist
  - [x] My code follows the project's style guidelines
  - [x] I have performed a self-review of my code
  - [x] I have tested my changes thoroughly
  - [x] Any dependent changes have been merged and published

  ## Additional Notes

  - The pool caps (20/5/5min/2min) are hardcoded defaults matching #102; happy to make them configurable via env vars if preferred.
  - Pairing/connection behavior is unchanged — the store remains a direct DB connection; `GetDevice`/`NewDevice` per instance work as before.

## Summary by Sourcery

Reuse a single shared, capped SQL auth container for all WhatsApp client starts to eliminate database connection leaks and improve connection handling reliability.

Bug Fixes:
- Prevent Postgres connection pool leaks by avoiding creation of a new unbounded sqlstore container on every client start and reconnect.
- Ensure transient database initialization failures do not permanently poison the auth container initialization so later calls can recover.

Enhancements:
- Cap Postgres connection pool sizes and lifetimes for the shared auth container and restrict SQLite to a single connection for more predictable resource usage.

Tests:
- Add a SQLite-based regression test verifying that auth container creation retries after failure and that successful initialization reuses the same shared container instance.