### PR TITLE
feat(user): return PictureURL on POST /user/info

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3754,8 +3754,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/gin.H"
                         }
                     },
+                    "429": {
+                        "description": "WhatsApp rate limit",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "504": {
+                        "description": "WhatsApp query timeout",
                         "schema": {
                             "$ref": "#/definitions/gin.H"
                         }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3546,8 +3546,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/gin.H"
                         }
                     },
+                    "429": {
+                        "description": "WhatsApp rate limit",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "504": {
+                        "description": "WhatsApp query timeout",
                         "schema": {
                             "$ref": "#/definitions/gin.H"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3538,8 +3538,20 @@
                             "$ref": "#/definitions/gin.H"
                         }
                     },
+                    "429": {
+                        "description": "WhatsApp rate limit",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "504": {
+                        "description": "WhatsApp query timeout",
                         "schema": {
                             "$ref": "#/definitions/gin.H"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3746,8 +3746,20 @@
                             "$ref": "#/definitions/gin.H"
                         }
                     },
+                    "429": {
+                        "description": "WhatsApp rate limit",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
                     "500": {
                         "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/gin.H"
+                        }
+                    },
+                    "504": {
+                        "description": "WhatsApp query timeout",
                         "schema": {
                             "$ref": "#/definitions/gin.H"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -9666,8 +9666,16 @@ paths:
           description: Error on validation
           schema:
             $ref: '#/definitions/gin.H'
+        "429":
+          description: WhatsApp rate limit
+          schema:
+            $ref: '#/definitions/gin.H'
         "500":
           description: Internal server error
+          schema:
+            $ref: '#/definitions/gin.H'
+        "504":
+          description: WhatsApp query timeout
           schema:
             $ref: '#/definitions/gin.H'
       summary: Get a user

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -9530,8 +9530,16 @@ paths:
           description: Error on validation
           schema:
             $ref: '#/definitions/gin.H'
+        "429":
+          description: WhatsApp rate limit
+          schema:
+            $ref: '#/definitions/gin.H'
         "500":
           description: Internal server error
+          schema:
+            $ref: '#/definitions/gin.H'
+        "504":
+          description: WhatsApp query timeout
           schema:
             $ref: '#/definitions/gin.H'
       summary: Get a user's avatar

--- a/docs/wiki/guias-api/api-user.md
+++ b/docs/wiki/guias-api/api-user.md
@@ -64,6 +64,7 @@ apikey: SUA-CHAVE-API
         },
         "Status": "Olá! Estou usando WhatsApp.",
         "PictureID": "abc123",
+        "PictureURL": "https://pps.whatsapp.net/v/...",
         "Devices": ["5511999999999.0:1@s.whatsapp.net"],
         "LID": "lid_string"
       }
@@ -76,12 +77,13 @@ apikey: SUA-CHAVE-API
 - `VerifiedName`: Nome verificado (empresas) ou null
 - `Status`: Recado/status do usuário
 - `PictureID`: ID da foto de perfil
+- `PictureURL`: URL da foto de perfil (preview; vazio se indisponível). Para imagem completa use `POST /user/avatar`
 - `Devices`: Lista de dispositivos conectados
 - `LID`: Local ID (se disponível)
 
 **Exemplo cURL**:
 ```bash
-curl -X POST http://localhost:4000/user/info \
+curl -X POST http://localhost:${SERVER_PORT}/user/info \
   -H "Content-Type: application/json" \
   -H "apikey: SUA-CHAVE-API" \
   -d '{

--- a/docs/wiki/guias-api/api-user.md
+++ b/docs/wiki/guias-api/api-user.md
@@ -45,7 +45,23 @@ apikey: SUA-CHAVE-API
 
 | Campo | Tipo | Obrigatório | Descrição |
 |-------|------|-------------|-----------|
-| `number` | array | ✅ Sim | Array de números a consultar |
+| `number` | array | ✅ Sim | Array de identificadores a consultar |
+
+**Query canônica (ordem recomendada):**
+
+1. `@lid` — quando conhecido (ex.: `123456789012345@lid`)
+2. PN JID — `556699956041@s.whatsapp.net` (já canônico)
+3. Dígitos — último recurso; números BR “sujos” (9º dígito extra) podem falhar ou retornar timeout rápido
+
+Prefira o JID/`@lid` já gravado pela sessão. Para URL de foto confiável, use também `POST /user/avatar` (especialmente com `@lid`).
+
+**Respostas de erro relevantes:**
+
+| HTTP | Quando |
+|------|--------|
+| 429 | WhatsApp `rate-overlimit` (faça backoff; não trate como 500 genérico) |
+| 504 | Timeout da query usync |
+| 500 | Demais falhas |
 
 **Resposta de Sucesso (200)**:
 ```json
@@ -77,7 +93,7 @@ apikey: SUA-CHAVE-API
 - `VerifiedName`: Nome verificado (empresas) ou null
 - `Status`: Recado/status do usuário
 - `PictureID`: ID da foto de perfil
-- `PictureURL`: URL da foto de perfil (preview; vazio se indisponível). Para imagem completa use `POST /user/avatar`
+- `PictureURL`: URL da foto de perfil (preview best-effort; vazio se indisponível ou sob rate-limit). Para imagem completa use `POST /user/avatar`
 - `Devices`: Lista de dispositivos conectados
 - `LID`: Local ID (se disponível)
 
@@ -181,8 +197,10 @@ Obtém a URL da foto de perfil de um usuário.
 
 | Campo | Tipo | Obrigatório | Descrição |
 |-------|------|-------------|-----------|
-| `number` | string | ✅ Sim | Número do usuário |
+| `number` | string | ✅ Sim | `@lid`, PN JID ou dígitos (mesma ordem canônica de `/user/info`) |
 | `preview` | bool | ❌ Não | Se true, retorna preview (menor resolução) |
+
+A request é limitada a ~8s. Preferir `@lid` ou PN JID canônico; dígitos ambíguos podem retornar **504** rapidamente em vez de hang longo.
 
 **Resposta de Sucesso (200)**:
 ```json
@@ -197,7 +215,14 @@ Obtém a URL da foto de perfil de um usuário.
 }
 ```
 
-**Resposta de Erro (500)**:
+**Respostas de erro**:
+
+| HTTP | Exemplo |
+|------|---------|
+| 429 | WhatsApp `rate-overlimit` |
+| 504 | Timeout da query de foto |
+| 500 | Sem foto / foto oculta / demais falhas (`no profile picture found`, …) |
+
 ```json
 {
   "error": "no profile picture found"
@@ -206,7 +231,7 @@ Obtém a URL da foto de perfil de um usuário.
 
 **Exemplo cURL**:
 ```bash
-curl -X POST http://localhost:4000/user/avatar \
+curl -X POST http://localhost:${SERVER_PORT}/user/avatar \
   -H "Content-Type: application/json" \
   -H "apikey: SUA-CHAVE-API" \
   -d '{

--- a/docs/wiki/guias-api/api-user.md
+++ b/docs/wiki/guias-api/api-user.md
@@ -93,7 +93,7 @@ Prefira o JID/`@lid` já gravado pela sessão. Para URL de foto confiável, use 
 - `VerifiedName`: Nome verificado (empresas) ou null
 - `Status`: Recado/status do usuário
 - `PictureID`: ID da foto de perfil
-- `PictureURL`: URL da foto de perfil (preview best-effort; vazio se indisponível ou sob rate-limit). Para imagem completa use `POST /user/avatar`
+- `PictureURL`: URL da foto de perfil (preview best-effort com budget total de ~5s; vazio se indisponível, sem `PictureID`, sob rate-limit ou budget esgotado). Para imagem completa use `POST /user/avatar`
 - `Devices`: Lista de dispositivos conectados
 - `LID`: Local ID (se disponível)
 

--- a/pkg/user/handler/user_handler.go
+++ b/pkg/user/handler/user_handler.go
@@ -12,12 +12,14 @@ import (
 )
 
 // writeUserWAError maps WhatsApp IQ / context errors to honest HTTP statuses.
-// rate-overlimit → 429; IQ/context timeout → 504; everything else → 500.
+// rate-overlimit → 429; IQ/context timeout or cancel → 504; everything else → 500.
 func writeUserWAError(ctx *gin.Context, err error) {
 	switch {
 	case errors.Is(err, whatsmeow.ErrIQRateOverLimit):
 		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
-	case errors.Is(err, whatsmeow.ErrIQTimedOut), errors.Is(err, context.DeadlineExceeded):
+	case errors.Is(err, whatsmeow.ErrIQTimedOut),
+		errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, context.Canceled):
 		ctx.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
 	default:
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/pkg/user/handler/user_handler.go
+++ b/pkg/user/handler/user_handler.go
@@ -54,7 +54,9 @@ type userHandler struct {
 // @Param message body user_service.CheckUserStruct true "User data"
 // @Success 200 {object} gin.H "success"
 // @Failure 400 {object} gin.H "Error on validation"
+// @Failure 429 {object} gin.H "WhatsApp rate limit"
 // @Failure 500 {object} gin.H "Internal server error"
+// @Failure 504 {object} gin.H "WhatsApp query timeout"
 // @Router /user/info [post]
 func (u *userHandler) GetUser(ctx *gin.Context) {
 	getInstance := ctx.MustGet("instance")
@@ -77,9 +79,9 @@ func (u *userHandler) GetUser(ctx *gin.Context) {
 		return
 	}
 
-	uc, err := u.userService.GetUser(data, instance)
+	uc, err := u.userService.GetUser(ctx.Request.Context(), data, instance)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		writeUserWAError(ctx, err)
 		return
 	}
 

--- a/pkg/user/handler/user_handler.go
+++ b/pkg/user/handler/user_handler.go
@@ -1,12 +1,28 @@
 package user_handler
 
 import (
+	"context"
+	"errors"
 	"net/http"
 
 	instance_model "github.com/evolution-foundation/evolution-go/pkg/instance/model"
 	user_service "github.com/evolution-foundation/evolution-go/pkg/user/service"
 	"github.com/gin-gonic/gin"
+	"go.mau.fi/whatsmeow"
 )
+
+// writeUserWAError maps WhatsApp IQ / context errors to honest HTTP statuses.
+// rate-overlimit → 429; IQ/context timeout → 504; everything else → 500.
+func writeUserWAError(ctx *gin.Context, err error) {
+	switch {
+	case errors.Is(err, whatsmeow.ErrIQRateOverLimit):
+		ctx.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+	case errors.Is(err, whatsmeow.ErrIQTimedOut), errors.Is(err, context.DeadlineExceeded):
+		ctx.JSON(http.StatusGatewayTimeout, gin.H{"error": err.Error()})
+	default:
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
 
 type UserHandler interface {
 	GetUser(ctx *gin.Context)
@@ -118,7 +134,9 @@ func (u *userHandler) CheckUser(ctx *gin.Context) {
 // @Param message body user_service.GetAvatarStruct true "Avatar data"
 // @Success 200 {object} gin.H "success"
 // @Failure 400 {object} gin.H "Error on validation"
+// @Failure 429 {object} gin.H "WhatsApp rate limit"
 // @Failure 500 {object} gin.H "Internal server error"
+// @Failure 504 {object} gin.H "WhatsApp query timeout"
 // @Router /user/avatar [post]
 func (u *userHandler) GetAvatar(ctx *gin.Context) {
 	getInstance := ctx.MustGet("instance")
@@ -146,9 +164,9 @@ func (u *userHandler) GetAvatar(ctx *gin.Context) {
 		return
 	}
 
-	pic, err := u.userService.GetAvatar(data, instance)
+	pic, err := u.userService.GetAvatar(ctx.Request.Context(), data, instance)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		writeUserWAError(ctx, err)
 		return
 	}
 

--- a/pkg/user/handler/user_wa_error_test.go
+++ b/pkg/user/handler/user_wa_error_test.go
@@ -1,0 +1,65 @@
+package user_handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.mau.fi/whatsmeow"
+)
+
+func TestWriteUserWAError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{
+			name:       "rate overlimit",
+			err:        fmt.Errorf("usync: %w", whatsmeow.ErrIQRateOverLimit),
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name:       "iq timeout",
+			err:        fmt.Errorf("avatar: %w", whatsmeow.ErrIQTimedOut),
+			wantStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:       "context deadline",
+			err:        fmt.Errorf("avatar: %w", context.DeadlineExceeded),
+			wantStatus: http.StatusGatewayTimeout,
+		},
+		{
+			name:       "other error",
+			err:        errors.New("no profile picture found"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			writeUserWAError(c, tt.err)
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			var body map[string]string
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				t.Fatalf("unmarshal body: %v", err)
+			}
+			if body["error"] == "" {
+				t.Fatal("expected non-empty error field")
+			}
+		})
+	}
+}

--- a/pkg/user/handler/user_wa_error_test.go
+++ b/pkg/user/handler/user_wa_error_test.go
@@ -37,6 +37,11 @@ func TestWriteUserWAError(t *testing.T) {
 			wantStatus: http.StatusGatewayTimeout,
 		},
 		{
+			name:       "context canceled",
+			err:        fmt.Errorf("avatar: %w", context.Canceled),
+			wantStatus: http.StatusGatewayTimeout,
+		},
+		{
 			name:       "other error",
 			err:        errors.New("no profile picture found"),
 			wantStatus: http.StatusInternalServerError,

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -24,8 +24,14 @@ const avatarRequestTimeout = 8 * time.Second
 // clientReadyWait is the max time to wait after StartInstance before failing.
 const clientReadyWait = 2 * time.Second
 
+// userInfoRequestTimeout bounds the usync IQ on POST /user/info.
+const userInfoRequestTimeout = 10 * time.Second
+
+// pictureURLEnrichTimeout is a best-effort preview fetch after usync; failures leave PictureURL empty.
+const pictureURLEnrichTimeout = 5 * time.Second
+
 type UserService interface {
-	GetUser(data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error)
+	GetUser(ctx context.Context, data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error)
 	CheckUser(data *CheckUserStruct, instance *instance_model.Instance) (*CheckUserCollection, error)
 	GetAvatar(ctx context.Context, data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error)
 	GetContacts(instance *instance_model.Instance) ([]ContactInfo, error)
@@ -174,10 +180,14 @@ func (u *userService) waitForClientReady(ctx context.Context, instanceId string,
 	}
 }
 
-func (u *userService) GetUser(data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error) {
+func (u *userService) GetUser(ctx context.Context, data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error) {
 	client, err := u.ensureClientConnected(instance.Id)
 	if err != nil {
 		return nil, err
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	var jids []types.JID
@@ -186,10 +196,20 @@ func (u *userService) GetUser(data *CheckUserStruct, instance *instance_model.In
 		if !ok {
 			return nil, errors.New("invalid phone number")
 		}
-		// usync IQ also requires a digits-only user JID (no "+" prefix).
-		jids = append(jids, utils.CanonicalJID(jid).ToNonAD())
+		jid = utils.CanonicalJID(jid).ToNonAD()
+		// Usync is more reliable on PN JIDs; resolve @lid via store when possible.
+		if jid.Server == types.HiddenUserServer && client.Store.LIDs != nil {
+			if pn, lidErr := client.Store.LIDs.GetPNForLID(ctx, jid); lidErr == nil && !pn.IsEmpty() {
+				u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Resolved LID %s to PN %s for usync", instance.Id, jid, pn)
+				jid = utils.CanonicalJID(pn).ToNonAD()
+			}
+		}
+		jids = append(jids, jid)
 	}
-	resp, err := client.GetUserInfo(context.Background(), jids)
+
+	usyncCtx, cancel := context.WithTimeout(ctx, userInfoRequestTimeout)
+	defer cancel()
+	resp, err := client.GetUserInfo(usyncCtx, jids)
 	if err != nil {
 		return nil, err
 	}
@@ -201,14 +221,14 @@ func (u *userService) GetUser(data *CheckUserStruct, instance *instance_model.In
 		// Consultar LID Store para obter LID associado ao JID
 		var lidStr *string
 		if client.Store.LIDs != nil {
-			if lid, err := client.Store.LIDs.GetLIDForPN(context.TODO(), jid); err == nil && !lid.IsEmpty() {
+			if lid, err := client.Store.LIDs.GetLIDForPN(ctx, jid); err == nil && !lid.IsEmpty() {
 				lidString := fmt.Sprintf("%v", lid)
 				lidStr = &lidString
 			}
 		}
 
 		pictureURL := ""
-		pic, picErr := u.fetchProfilePicture(context.Background(), client, jid, true, 25*time.Second)
+		pic, picErr := u.fetchProfilePicture(ctx, client, jid, true, pictureURLEnrichTimeout)
 		if picErr != nil {
 			u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Failed to enrich PictureURL for %s: %v", instance.Id, jid, picErr)
 		} else if pic != nil {

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -335,6 +335,10 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 	if !ok {
 		return nil, errors.New("invalid phone number")
 	}
+	// Profile picture IQ is a RAW node (Target=jid). CreateJID/ParseJID may
+	// prefix "+" which WhatsApp does not accept on this path — same class of
+	// bug as typing/receipts (see utils.CanonicalJID).
+	jid = utils.CanonicalJID(jid).ToNonAD()
 
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
 
@@ -351,7 +355,7 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 	})
 	if err != nil {
 		u.loggerWrapper.GetLogger(instance.Id).LogError("[%s] GetProfilePictureInfo failed: %v", instance.Id, err)
-		return nil, err
+		return nil, fmt.Errorf("get profile picture for %s: %w", jid, err)
 	}
 
 	if pic == nil {

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -17,10 +17,14 @@ import (
 	"go.mau.fi/whatsmeow/types/events"
 )
 
+// avatarRequestTimeout bounds POST /user/avatar so clients (e.g. Chatwoot at 12s)
+// get a clear HTTP error instead of a hung connection waiting for the ~75s IQ default.
+const avatarRequestTimeout = 8 * time.Second
+
 type UserService interface {
 	GetUser(data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error)
 	CheckUser(data *CheckUserStruct, instance *instance_model.Instance) (*CheckUserCollection, error)
-	GetAvatar(data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error)
+	GetAvatar(ctx context.Context, data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error)
 	GetContacts(instance *instance_model.Instance) ([]ContactInfo, error)
 	GetPrivacy(instance *instance_model.Instance) (types.PrivacySettings, error)
 	SetPrivacy(data *PrivacyStruct, instance *instance_model.Instance) (*types.PrivacySettings, error)
@@ -315,7 +319,7 @@ func (u *userService) mergeCheckUserResults(original, retry *CheckUserCollection
 	return merged
 }
 
-func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error) {
+func (u *userService) GetAvatar(ctx context.Context, data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error) {
 	client, err := u.ensureClientConnected(instance.Id)
 	if err != nil {
 		return nil, err
@@ -342,15 +346,14 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
 
-	var pic *types.ProfilePictureInfo
-
-	// 🔒 FIX: Adicionar timeout ao contexto para evitar que a requisição trave indefinidamente
-	// Usar timeout maior que o padrão do sendIQ (75s) para dar tempo suficiente
-	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Second)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, avatarRequestTimeout)
 	defer cancel()
 
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Starting GetProfilePictureInfo request...", instance.Id)
-	pic, err = client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
+	pic, err := client.GetProfilePictureInfo(reqCtx, jid, &whatsmeow.GetProfilePictureParams{
 		Preview: data.Preview,
 	})
 	if err != nil {

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -27,8 +27,9 @@ const clientReadyWait = 2 * time.Second
 // userInfoRequestTimeout bounds the usync IQ on POST /user/info.
 const userInfoRequestTimeout = 10 * time.Second
 
-// pictureURLEnrichTimeout is a best-effort preview fetch after usync; failures leave PictureURL empty.
-const pictureURLEnrichTimeout = 5 * time.Second
+// pictureURLEnrichBudget is the total wall-clock budget for best-effort PictureURL
+// enrichment after usync (shared across all users in the response).
+const pictureURLEnrichBudget = 5 * time.Second
 
 type UserService interface {
 	GetUser(ctx context.Context, data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error)
@@ -181,13 +182,13 @@ func (u *userService) waitForClientReady(ctx context.Context, instanceId string,
 }
 
 func (u *userService) GetUser(ctx context.Context, data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error) {
-	client, err := u.ensureClientConnected(instance.Id)
-	if err != nil {
-		return nil, err
-	}
-
 	if ctx == nil {
 		ctx = context.Background()
+	}
+
+	client, err := u.ensureClientConnectedCtx(ctx, instance.Id)
+	if err != nil {
+		return nil, err
 	}
 
 	var jids []types.JID
@@ -217,6 +218,9 @@ func (u *userService) GetUser(ctx context.Context, data *CheckUserStruct, instan
 	uc := new(UserCollection)
 	uc.Users = make(map[types.JID]UserInfo)
 
+	enrichDeadline := time.Now().Add(pictureURLEnrichBudget)
+	skipPictureEnrich := false
+
 	for jid, whatsmeowInfo := range resp {
 		// Consultar LID Store para obter LID associado ao JID
 		var lidStr *string
@@ -228,11 +232,23 @@ func (u *userService) GetUser(ctx context.Context, data *CheckUserStruct, instan
 		}
 
 		pictureURL := ""
-		pic, picErr := u.fetchProfilePicture(ctx, client, jid, true, pictureURLEnrichTimeout)
-		if picErr != nil {
-			u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Failed to enrich PictureURL for %s: %v", instance.Id, jid, picErr)
-		} else if pic != nil {
-			pictureURL = pic.URL
+		if !skipPictureEnrich && whatsmeowInfo.PictureID != "" {
+			remaining := time.Until(enrichDeadline)
+			if remaining <= 0 {
+				skipPictureEnrich = true
+				u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] PictureURL enrich budget exhausted; skipping remaining users", instance.Id)
+			} else {
+				pic, picErr := u.fetchProfilePicture(ctx, client, jid, true, remaining)
+				if picErr != nil {
+					u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Failed to enrich PictureURL for %s: %v", instance.Id, jid, picErr)
+					if errors.Is(picErr, whatsmeow.ErrIQRateOverLimit) {
+						skipPictureEnrich = true
+						u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Stopping PictureURL enrich after rate-overlimit", instance.Id)
+					}
+				} else if pic != nil {
+					pictureURL = pic.URL
+				}
+			}
 		}
 
 		// Converter para nossa estrutura UserInfo que inclui LID

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -21,6 +21,9 @@ import (
 // get a clear HTTP error instead of a hung connection waiting for the ~75s IQ default.
 const avatarRequestTimeout = 8 * time.Second
 
+// clientReadyWait is the max time to wait after StartInstance before failing.
+const clientReadyWait = 2 * time.Second
+
 type UserService interface {
 	GetUser(data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error)
 	CheckUser(data *CheckUserStruct, instance *instance_model.Instance) (*CheckUserCollection, error)
@@ -113,6 +116,14 @@ type PrivacyStruct struct {
 }
 
 func (u *userService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	return u.ensureClientConnectedCtx(context.Background(), instanceId)
+}
+
+func (u *userService) ensureClientConnectedCtx(ctx context.Context, instanceId string) (*whatsmeow.Client, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	client := u.clientPointer[instanceId]
 	u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
@@ -124,20 +135,10 @@ func (u *userService) ensureClientConnected(instanceId string) (*whatsmeow.Clien
 			return nil, errors.New("no active session found")
 		}
 
-		u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
-		time.Sleep(2 * time.Second)
-
-		client = u.clientPointer[instanceId]
-		u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
-			instanceId,
-			client != nil,
-			client != nil && client.IsConnected())
-
-		if client == nil || !client.IsConnected() {
-			u.loggerWrapper.GetLogger(instanceId).LogError("[%s] New client validation failed - Exists: %v, Connected: %v",
-				instanceId,
-				client != nil,
-				client != nil && client.IsConnected())
+		u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting up to %s for connection...", instanceId, clientReadyWait)
+		client, err = u.waitForClientReady(ctx, instanceId, clientReadyWait)
+		if err != nil {
+			u.loggerWrapper.GetLogger(instanceId).LogError("[%s] New client validation failed: %v", instanceId, err)
 			return nil, errors.New("no active session found")
 		}
 	} else if !client.IsConnected() {
@@ -149,6 +150,27 @@ func (u *userService) ensureClientConnected(instanceId string) (*whatsmeow.Clien
 
 	u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Client successfully validated - Connected: %v", instanceId, client.IsConnected())
 	return client, nil
+}
+
+func (u *userService) waitForClientReady(ctx context.Context, instanceId string, maxWait time.Duration) (*whatsmeow.Client, error) {
+	deadline := time.Now().Add(maxWait)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		client := u.clientPointer[instanceId]
+		if client != nil && client.IsConnected() {
+			return client, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, errors.New("client not ready within wait window")
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("waiting for client: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func (u *userService) GetUser(data *CheckUserStruct, instance *instance_model.Instance) (*UserCollection, error) {
@@ -320,7 +342,11 @@ func (u *userService) mergeCheckUserResults(original, retry *CheckUserCollection
 }
 
 func (u *userService) GetAvatar(ctx context.Context, data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error) {
-	client, err := u.ensureClientConnected(instance.Id)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	client, err := u.ensureClientConnectedCtx(ctx, instance.Id)
 	if err != nil {
 		return nil, err
 	}
@@ -343,12 +369,16 @@ func (u *userService) GetAvatar(ctx context.Context, data *GetAvatarStruct, inst
 	// prefix "+" which WhatsApp does not accept on this path — same class of
 	// bug as typing/receipts (see utils.CanonicalJID).
 	jid = utils.CanonicalJID(jid).ToNonAD()
+	// Prefer PN JID when the store knows the mapping for @lid.
+	if jid.Server == types.HiddenUserServer && client.Store.LIDs != nil {
+		if pn, lidErr := client.Store.LIDs.GetPNForLID(ctx, jid); lidErr == nil && !pn.IsEmpty() {
+			u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Resolved LID %s to PN %s for avatar", instance.Id, jid, pn)
+			jid = utils.CanonicalJID(pn).ToNonAD()
+		}
+	}
 
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	reqCtx, cancel := context.WithTimeout(ctx, avatarRequestTimeout)
 	defer cancel()
 

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -58,6 +58,7 @@ type UserInfo struct {
 	VerifiedName *types.VerifiedName
 	Status       string
 	PictureID    string
+	PictureURL   string
 	Devices      []types.JID
 	LID          *string // The local ID (if available)
 }
@@ -185,7 +186,8 @@ func (u *userService) GetUser(data *CheckUserStruct, instance *instance_model.In
 		if !ok {
 			return nil, errors.New("invalid phone number")
 		}
-		jids = append(jids, jid)
+		// usync IQ also requires a digits-only user JID (no "+" prefix).
+		jids = append(jids, utils.CanonicalJID(jid).ToNonAD())
 	}
 	resp, err := client.GetUserInfo(context.Background(), jids)
 	if err != nil {
@@ -205,11 +207,20 @@ func (u *userService) GetUser(data *CheckUserStruct, instance *instance_model.In
 			}
 		}
 
+		pictureURL := ""
+		pic, picErr := u.fetchProfilePicture(context.Background(), client, jid, true, 25*time.Second)
+		if picErr != nil {
+			u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Failed to enrich PictureURL for %s: %v", instance.Id, jid, picErr)
+		} else if pic != nil {
+			pictureURL = pic.URL
+		}
+
 		// Converter para nossa estrutura UserInfo que inclui LID
 		info := UserInfo{
 			VerifiedName: whatsmeowInfo.VerifiedName,
 			Status:       whatsmeowInfo.Status,
 			PictureID:    whatsmeowInfo.PictureID,
+			PictureURL:   pictureURL,
 			Devices:      whatsmeowInfo.Devices,
 			LID:          lidStr,
 		}
@@ -341,6 +352,26 @@ func (u *userService) mergeCheckUserResults(original, retry *CheckUserCollection
 	return merged
 }
 
+// fetchProfilePicture requests a profile picture URL for jid.
+// Never pass ExistingID here: when the picture is unchanged whatsmeow returns
+// nil with no error and no URL.
+func (u *userService) fetchProfilePicture(parent context.Context, client *whatsmeow.Client, jid types.JID, preview bool, timeout time.Duration) (*types.ProfilePictureInfo, error) {
+	jid = utils.CanonicalJID(jid).ToNonAD()
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	pic, err := client.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{
+		Preview: preview,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get profile picture for %s: %w", jid, err)
+	}
+	return pic, nil
+}
+
 func (u *userService) GetAvatar(ctx context.Context, data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -378,17 +409,12 @@ func (u *userService) GetAvatar(ctx context.Context, data *GetAvatarStruct, inst
 	}
 
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
-
-	reqCtx, cancel := context.WithTimeout(ctx, avatarRequestTimeout)
-	defer cancel()
-
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Starting GetProfilePictureInfo request...", instance.Id)
-	pic, err := client.GetProfilePictureInfo(reqCtx, jid, &whatsmeow.GetProfilePictureParams{
-		Preview: data.Preview,
-	})
+
+	pic, err := u.fetchProfilePicture(ctx, client, jid, data.Preview, avatarRequestTimeout)
 	if err != nil {
 		u.loggerWrapper.GetLogger(instance.Id).LogError("[%s] GetProfilePictureInfo failed: %v", instance.Id, err)
-		return nil, fmt.Errorf("get profile picture for %s: %w", jid, err)
+		return nil, err
 	}
 
 	if pic == nil {


### PR DESCRIPTION
## Description

`POST /user/info` never returned a profile picture URL (only `PictureID`) and, with a `+`-prefixed JID, also failed with usync `"info query timed out"` — same root cause as #76 / #120.

### What changed

1. **Canonical JID for `GetUserInfo`** — strip `+` via `CanonicalJID` + `ToNonAD` before the usync query.
2. **Additive field `PictureURL`** on `UserInfo` — best-effort preview URL after `GetUserInfo` (**5s** timeout). Failures leave `PictureURL` empty and do **not** fail the whole `/info` response.
3. Shared private helper `fetchProfilePicture` (used by `/user/avatar` and `/user/info`). **Does not** pass `ExistingID`.
4. **Addendum 18/jul (production Chatwoot report):**
   - Map usync `rate-overlimit` → **HTTP 429**; IQ/context timeout → **HTTP 504**
   - Bound usync to **10s** via request context
   - Resolve `@lid` → PN via `Store.LIDs.GetPNForLID` before usync when available (P3 consistency)
   - Wiki: canonical query order `@lid` → PN JID → digits; document 429/504

### Response shape (additive, non-breaking)

```json
{
  "PictureID": "57501569",
  "PictureURL": "https://pps.whatsapp.net/v/..."
}
```

For full-resolution image, clients should still use `POST /user/avatar` with `preview: false`.

## Related Issue

Related to #76  
Depends on #120 (this branch includes those fix commits; rebase after #120 merges if needed)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (rate-limit status + LID usync consistency)

## Testing

- [x] Manual testing completed (PictureURL path)
- [x] Unit test for HTTP status mapping (from #120)
- [x] No breaking changes (`PictureURL` is additive; expected WA errors unchanged)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] Docs updated for the new response field and canonical query order

## Additional Notes

Please review/merge #120 first if you prefer the bugfix alone; this PR stacks on that branch.