### PR TITLE
fix: decrypt inbound message edits and clarify revoke webhooks

### DIFF
--- a/docs/wiki/recursos-avancados/events-system.md
+++ b/docs/wiki/recursos-avancados/events-system.md
@@ -644,10 +644,23 @@ Quando um contato edita uma mensagem, o evento continua sendo `Message` (subscri
 Após descriptografia, o payload inclui:
 
 - `IsEdit: true`
+- `messageType: "edit"`
+- `Message.protocolMessage.typeName: "MESSAGE_EDIT"` (o campo numérico `type` continua presente)
 - Texto novo em `Message.protocolMessage.editedMessage` (ex.: `conversation` ou `extendedTextMessage`)
 - ID da mensagem original em `Message.protocolMessage.key.id` (ou, antes do decrypt, em `secretEncryptedMessage.targetMessageKey.id`)
 
 **Limitação**: o decrypt usa o `messageSecret` da mensagem original armazenado na sessão. Se a mensagem original não estiver no store (ex.: enviada antes da sessão atual), o webhook pode ainda chegar com `secretEncryptedMessage` cifrado e sem texto em claro.
+
+#### Exclusão (revoke) de mensagem
+
+Quando um contato apaga uma mensagem “para todos”, o evento também é `Message` (subscribe `MESSAGE`).
+
+O payload inclui:
+
+- `IsRevoke: true`
+- `messageType: "revoke"`
+- `Message.protocolMessage.typeName: "REVOKE"` (equivalente ao `type: 0` / `Info.Edit: "7"`)
+- ID da mensagem apagada em `Message.protocolMessage.key.id`
 
 ### Eventos de Grupos
 

--- a/docs/wiki/recursos-avancados/events-system.md
+++ b/docs/wiki/recursos-avancados/events-system.md
@@ -637,6 +637,18 @@ O Evolution GO usa dois níveis de classificação de eventos:
 - `Receipt` - Confirmação de leitura (`READ_RECEIPT`)
 - Reações, edições, deleções de mensagens
 
+#### Edição de mensagem recebida
+
+Quando um contato edita uma mensagem, o evento continua sendo `Message` (subscribe `MESSAGE`). Não existe categoria separada `MESSAGE_EDIT`.
+
+Após descriptografia, o payload inclui:
+
+- `IsEdit: true`
+- Texto novo em `Message.protocolMessage.editedMessage` (ex.: `conversation` ou `extendedTextMessage`)
+- ID da mensagem original em `Message.protocolMessage.key.id` (ou, antes do decrypt, em `secretEncryptedMessage.targetMessageKey.id`)
+
+**Limitação**: o decrypt usa o `messageSecret` da mensagem original armazenado na sessão. Se a mensagem original não estiver no store (ex.: enviada antes da sessão atual), o webhook pode ainda chegar com `secretEncryptedMessage` cifrado e sem texto em claro.
+
 ### Eventos de Grupos
 
 **Categoria**: `GROUP`

--- a/docs/wiki/recursos-avancados/events-system.md
+++ b/docs/wiki/recursos-avancados/events-system.md
@@ -647,9 +647,9 @@ Após descriptografia, o payload inclui:
 - `messageType: "edit"`
 - `Message.protocolMessage.typeName: "MESSAGE_EDIT"` (o campo numérico `type` continua presente)
 - Texto novo em `Message.protocolMessage.editedMessage` (ex.: `conversation` ou `extendedTextMessage`)
-- ID da mensagem original em `Message.protocolMessage.key.id` (ou, antes do decrypt, em `secretEncryptedMessage.targetMessageKey.id`)
+- ID da mensagem original em `Message.protocolMessage.key.ID` (ou, antes do decrypt, em `secretEncryptedMessage.targetMessageKey.ID`)
 
-**Limitação**: o decrypt usa o `messageSecret` da mensagem original armazenado na sessão. Se a mensagem original não estiver no store (ex.: enviada antes da sessão atual), o webhook pode ainda chegar com `secretEncryptedMessage` cifrado e sem texto em claro.
+**Limitação**: o decrypt usa o `messageSecret` da mensagem original armazenado na sessão. Se a mensagem original não estiver no store (ex.: enviada antes da sessão atual), o webhook ainda chega com `secretEncryptedMessage` cifrado (sem texto em claro), mas mantém `IsEdit: true` e `messageType: "edit"` para identificar a ação.
 
 #### Exclusão (revoke) de mensagem
 
@@ -660,7 +660,7 @@ O payload inclui:
 - `IsRevoke: true`
 - `messageType: "revoke"`
 - `Message.protocolMessage.typeName: "REVOKE"` (equivalente ao `type: 0` / `Info.Edit: "7"`)
-- ID da mensagem apagada em `Message.protocolMessage.key.id`
+- ID da mensagem apagada em `Message.protocolMessage.key.ID`
 
 ### Eventos de Grupos
 

--- a/docs/wiki/recursos-avancados/events-system.md
+++ b/docs/wiki/recursos-avancados/events-system.md
@@ -649,7 +649,7 @@ Após descriptografia, o payload inclui:
 - Texto novo em `Message.protocolMessage.editedMessage` (ex.: `conversation` ou `extendedTextMessage`)
 - ID da mensagem original em `Message.protocolMessage.key.ID` (ou, antes do decrypt, em `secretEncryptedMessage.targetMessageKey.ID`)
 
-**Limitação**: o decrypt usa o `messageSecret` da mensagem original armazenado na sessão. Se a mensagem original não estiver no store (ex.: enviada antes da sessão atual), o webhook ainda chega com `secretEncryptedMessage` cifrado (sem texto em claro), mas mantém `IsEdit: true` e `messageType: "edit"` para identificar a ação.
+**Limitação**: o decrypt usa o `messageSecret` da mensagem original armazenado na sessão e deve rodar **antes** de qualquer normalização LID→PN do `Info.Sender`/`Chat`. Se o decrypt falhar, o webhook ainda chega com `IsEdit: true`, `messageType: "edit"` e `decryptFailed: true` (pode manter `secretEncryptedMessage` sem texto em claro).
 
 #### Exclusão (revoke) de mensagem
 

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1236,10 +1236,32 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			}()
 		}
 
+		// Newer WhatsApp clients send edits as SecretEncryptedMessage(MESSAGE_EDIT).
+		// Decrypt before classification/marshal so the webhook includes the new text.
+		if enc := evt.Message.GetSecretEncryptedMessage(); enc != nil &&
+			enc.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+			decrypted, err := mycli.WAClient.DecryptSecretEncryptedMessage(context.Background(), evt)
+			if err != nil {
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
+					"[%s] Failed to decrypt secret encrypted message edit (original secret may be missing): %v",
+					mycli.userID, err)
+			} else {
+				evt.Message = decrypted
+				evt.IsEdit = true
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo(
+					"[%s] Decrypted secret encrypted message edit for %s", mycli.userID, evt.Info.ID)
+			}
+		}
+
 		parsedMessageType := utils.GetMessageType(evt.Message)
 		if parsedMessageType == "ignore" || strings.HasPrefix(parsedMessageType, "unknown_protocol_") {
 			mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Message ignored because it's a unknown protocol message", mycli.userID)
 			return
+		}
+
+		// Legacy plaintext edits arrive as ProtocolMessage MESSAGE_EDIT (IsEdit stays false otherwise).
+		if parsedMessageType == "edit" {
+			evt.IsEdit = true
 		}
 
 		if postMap["data"] != nil {

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1182,6 +1182,46 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			return
 		}
 
+		// Decrypt MESSAGE_EDIT BEFORE LID/PN JID swap. whatsmeow derives the edit
+		// key from Info.Sender/Chat as received on the wire; swapping first causes
+		// cipher: message authentication failed even when the secret exists.
+		secretEditEnvelope := false
+		decryptFailed := false
+		if enc := evt.Message.GetSecretEncryptedMessage(); enc != nil &&
+			enc.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
+			secretEditEnvelope = true
+			evt.IsEdit = true
+
+			client := mycli.clientPointer[mycli.userID]
+			if client == nil {
+				client = mycli.WAClient
+			}
+			if client == nil {
+				decryptFailed = true
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
+					"[%s] No client available to decrypt secret encrypted message edit", mycli.userID)
+			} else {
+				decrypted, err := client.DecryptSecretEncryptedMessage(context.Background(), evt)
+				if err != nil {
+					decryptFailed = true
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
+						"[%s] Failed to decrypt secret encrypted message edit: %v",
+						mycli.userID, err)
+				} else {
+					evt.Message = decrypted
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo(
+						"[%s] Decrypted secret encrypted message edit for %s", mycli.userID, evt.Info.ID)
+				}
+			}
+		}
+
+		// EditedMessage wrapper (legacy wire format or post-decrypt). Do not call
+		// UnwrapRaw here — it resets Message from RawMessage and would undo decrypt.
+		if evt.Message != nil && evt.Message.GetEditedMessage().GetMessage() != nil {
+			evt.Message = evt.Message.GetEditedMessage().GetMessage()
+			evt.IsEdit = true
+		}
+
 		// Trata o caso especial onde Sender é @lid e SenderAlt é @s.whatsapp.net
 		// Neste caso, devemos inverter: Sender e Chat devem ser @s.whatsapp.net, SenderAlt deve ser @lid
 		senderStr := evt.Info.Sender.String()
@@ -1236,42 +1276,6 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			}()
 		}
 
-		// Newer WhatsApp clients send edits as SecretEncryptedMessage(MESSAGE_EDIT).
-		// Decrypt before classification/marshal so the webhook includes the new text.
-		secretEditEnvelope := false
-		if enc := evt.Message.GetSecretEncryptedMessage(); enc != nil &&
-			enc.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
-			secretEditEnvelope = true
-			evt.IsEdit = true
-
-			client := mycli.clientPointer[mycli.userID]
-			if client == nil {
-				client = mycli.WAClient
-			}
-			if client == nil {
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
-					"[%s] No client available to decrypt secret encrypted message edit", mycli.userID)
-			} else {
-				decrypted, err := client.DecryptSecretEncryptedMessage(context.Background(), evt)
-				if err != nil {
-					mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
-						"[%s] Failed to decrypt secret encrypted message edit (original secret may be missing): %v",
-						mycli.userID, err)
-				} else {
-					evt.Message = decrypted
-					mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo(
-						"[%s] Decrypted secret encrypted message edit for %s", mycli.userID, evt.Info.ID)
-				}
-			}
-		}
-
-		// EditedMessage wrapper (legacy wire format or post-decrypt). Do not call
-		// UnwrapRaw here — it resets Message from RawMessage and would undo decrypt.
-		if evt.Message != nil && evt.Message.GetEditedMessage().GetMessage() != nil {
-			evt.Message = evt.Message.GetEditedMessage().GetMessage()
-			evt.IsEdit = true
-		}
-
 		parsedMessageType := utils.GetMessageType(evt.Message)
 		if parsedMessageType == "ignore" || strings.HasPrefix(parsedMessageType, "unknown_protocol_") {
 			mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Message ignored because it's a unknown protocol message", mycli.userID)
@@ -1324,6 +1328,9 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 				dataMap["IsEdit"] = true
 				dataMap["messageType"] = "edit"
 			}
+		}
+		if decryptFailed {
+			dataMap["decryptFailed"] = true
 		}
 
 		referral := extractReferralFromMessage(evt.Message)

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1238,19 +1238,38 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 
 		// Newer WhatsApp clients send edits as SecretEncryptedMessage(MESSAGE_EDIT).
 		// Decrypt before classification/marshal so the webhook includes the new text.
+		secretEditEnvelope := false
 		if enc := evt.Message.GetSecretEncryptedMessage(); enc != nil &&
 			enc.GetSecretEncType() == waE2E.SecretEncryptedMessage_MESSAGE_EDIT {
-			decrypted, err := mycli.WAClient.DecryptSecretEncryptedMessage(context.Background(), evt)
-			if err != nil {
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
-					"[%s] Failed to decrypt secret encrypted message edit (original secret may be missing): %v",
-					mycli.userID, err)
-			} else {
-				evt.Message = decrypted
-				evt.IsEdit = true
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo(
-					"[%s] Decrypted secret encrypted message edit for %s", mycli.userID, evt.Info.ID)
+			secretEditEnvelope = true
+			evt.IsEdit = true
+
+			client := mycli.clientPointer[mycli.userID]
+			if client == nil {
+				client = mycli.WAClient
 			}
+			if client == nil {
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
+					"[%s] No client available to decrypt secret encrypted message edit", mycli.userID)
+			} else {
+				decrypted, err := client.DecryptSecretEncryptedMessage(context.Background(), evt)
+				if err != nil {
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn(
+						"[%s] Failed to decrypt secret encrypted message edit (original secret may be missing): %v",
+						mycli.userID, err)
+				} else {
+					evt.Message = decrypted
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo(
+						"[%s] Decrypted secret encrypted message edit for %s", mycli.userID, evt.Info.ID)
+				}
+			}
+		}
+
+		// EditedMessage wrapper (legacy wire format or post-decrypt). Do not call
+		// UnwrapRaw here — it resets Message from RawMessage and would undo decrypt.
+		if evt.Message != nil && evt.Message.GetEditedMessage().GetMessage() != nil {
+			evt.Message = evt.Message.GetEditedMessage().GetMessage()
+			evt.IsEdit = true
 		}
 
 		parsedMessageType := utils.GetMessageType(evt.Message)
@@ -1259,8 +1278,7 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			return
 		}
 
-		// Legacy plaintext edits arrive as ProtocolMessage MESSAGE_EDIT (IsEdit stays false otherwise).
-		if parsedMessageType == "edit" {
+		if parsedMessageType == "edit" || secretEditEnvelope {
 			evt.IsEdit = true
 		}
 
@@ -1299,6 +1317,13 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			dataMap["IsRevoke"] = true
 			dataMap["messageType"] = "revoke"
 			setProtocolMessageTypeName(dataMap, "REVOKE")
+		default:
+			// Decrypt failed or plaintext not yet classified as "edit", but envelope
+			// already identified the event as an incoming message edit.
+			if secretEditEnvelope {
+				dataMap["IsEdit"] = true
+				dataMap["messageType"] = "edit"
+			}
 		}
 
 		referral := extractReferralFromMessage(evt.Message)

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1288,6 +1288,19 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			dataMap = make(map[string]interface{})
 		}
 
+		// Explicit action flags for edit/revoke — protocolMessage.type alone is a
+		// numeric enum (0 = REVOKE, 14 = MESSAGE_EDIT) and Info.Edit is opaque.
+		switch parsedMessageType {
+		case "edit":
+			dataMap["IsEdit"] = true
+			dataMap["messageType"] = "edit"
+			setProtocolMessageTypeName(dataMap, "MESSAGE_EDIT")
+		case "revoke":
+			dataMap["IsRevoke"] = true
+			dataMap["messageType"] = "revoke"
+			setProtocolMessageTypeName(dataMap, "REVOKE")
+		}
+
 		referral := extractReferralFromMessage(evt.Message)
 
 		if evt.Message.GetPollUpdateMessage() != nil {
@@ -2901,6 +2914,22 @@ func (w *whatsmeowService) ConfirmPasskey(instanceId string) error {
 	}
 	w.passkeyCeremony.SetConfirmed(instanceId)
 	return nil
+}
+
+// setProtocolMessageTypeName adds a human-readable protocolMessage.typeName
+// (e.g. REVOKE, MESSAGE_EDIT) without replacing the numeric type enum.
+func setProtocolMessageTypeName(dataMap map[string]interface{}, typeName string) {
+	message, ok := dataMap["Message"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	pm, ok := message["protocolMessage"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	pm["typeName"] = typeName
+	message["protocolMessage"] = pm
+	dataMap["Message"] = message
 }
 
 // cleanSenderID remove a parte ":numero" do sender ID para exibir apenas o remoteJid correto


### PR DESCRIPTION
## Description

Incoming WhatsApp **message edits** from contacts were delivered as `Message` webhooks with only `secretEncryptedMessage` (no plaintext). Consumers (e.g. Chatwoot) could detect the edit and original message ID, but could not apply the new text.

This PR:

1. **Decrypts** `SecretEncryptedMessage` with `secretEncType = MESSAGE_EDIT` via whatsmeow `DecryptSecretEncryptedMessage` before building the webhook payload.
2. Runs decrypt **before** the LID→PN JID swap. Swapping first caused `cipher: message authentication failed` even when the message secret existed in `whatsmeow_message_secrets` (LID-keyed store).
3. Unwraps the `EditedMessage` wrapper after decrypt (without calling `UnwrapRaw`, which would reset from `RawMessage`).
4. Sets consistent flags: `IsEdit`, `messageType: "edit"`, and `protocolMessage.typeName: "MESSAGE_EDIT"`.
5. On decrypt failure: keeps `IsEdit` / `messageType: "edit"` and adds `decryptFailed: true` (still no plaintext — documented).
6. For **revoke/delete for everyone**: sets `IsRevoke`, `messageType: "revoke"`, and `protocolMessage.typeName: "REVOKE"` so consumers do not rely only on opaque `Info.Edit: "7"` / numeric `type: 0`.
7. Documents the contract in `docs/wiki/recursos-avancados/events-system.md`.

Outbound `POST /message/edit` was already working; this PR only fixes **inbound** edit/revoke webhook usability.

## Related Issue

Closes #92

Related: #108 (same inbound edit plaintext gap; closed without a fix)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Examples (after fix)

### Inbound edit (contact edits on WhatsApp)

```json
{
  "event": "Message",
  "data": {
    "Info": {
      "IsFromMe": false,
      "ID": "<edit-event-id>",
      "Edit": "1",
      "Type": "text"
    },
    "IsEdit": true,
    "messageType": "edit",
    "Message": {
      "protocolMessage": {
        "type": 14,
        "typeName": "MESSAGE_EDIT",
        "key": { "ID": "<ORIGINAL_MESSAGE_ID>" },
        "editedMessage": {
          "conversation": "Texto editado pelo cliente"
        }
      }
    }
  }
}
```

`editedMessage.extendedTextMessage.text` is also valid.

**Consumer rules:**

| Need | Field |
|------|--------|
| Message to update | `Message.protocolMessage.key.ID` (not `Info.ID`) |
| New text | `editedMessage.conversation` or `editedMessage.extendedTextMessage.text` |
| Edit signal | `IsEdit` / `messageType: "edit"` / `Info.Edit: "1"` |

If decrypt fails: `decryptFailed: true` may be present with the encrypted envelope still in place.

### Inbound revoke (delete for everyone)

```json
{
  "event": "Message",
  "data": {
    "IsRevoke": true,
    "messageType": "revoke",
    "Message": {
      "protocolMessage": {
        "type": 0,
        "typeName": "REVOKE",
        "key": { "ID": "<ORIGINAL_MESSAGE_ID>" }
      }
    }
  }
}
```

### Outbound edit via API (unchanged, still works)

`POST /message/edit` + webhook echo with `IsFromMe: true` and plaintext in `editedMessage` — no regression expected.

## Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

Manual validation in production-like Docker:

1. Contact sends text → webhook with body.
2. Contact edits text → webhook contains `protocolMessage.editedMessage` plaintext (not only `secretEncryptedMessage`).
3. Contact deletes for everyone → `IsRevoke` / `typeName: "REVOKE"`.
4. Confirmed root cause of failed decrypt after first attempt: MAC error when decrypt ran after LID→PN swap; fixed by decrypting first.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [x] Any dependent changes have been merged and published

## Additional Notes

- Single concern: inbound edit/revoke webhook payload completeness for #92.
- Files touched: `pkg/whatsmeow/service/whatsmeow.go`, `docs/wiki/recursos-avancados/events-system.md`.
- No swagger / HTTP API changes.
- Does not add new subscribe event types (`MESSAGE_EDIT`); edits/revokes remain under `MESSAGE` → event `Message`.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Improve inbound WhatsApp message edit and revoke webhook payloads for better consumer handling of edits and deletions.

Bug Fixes:
- Decrypt inbound MESSAGE_EDIT secret encrypted payloads before JID normalization so edited message text is available in webhooks.
- Preserve edit classification when edits arrive via legacy EditedMessage wrappers and when decryption fails.

Enhancements:
- Add explicit webhook flags and protocolMessage.typeName for inbound edit and revoke events to make action type detection consistent.
- Introduce a helper to set human-readable protocolMessage.typeName while retaining numeric type values in webhook payloads.

Documentation:
- Document the structure and semantics of inbound edit and revoke webhook payloads, including decrypt behavior and limitations.