### PR TITLE
fix: panic on Archive event due to unchecked type assertion

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1817,12 +1817,15 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		doWebhook = true
 		postMap["event"] = "Archive"
 
-		dataMap := postMap["data"].(map[string]interface{})
-		dataMap["JID"] = evt.JID
-		dataMap["Timestamp"] = evt.Timestamp
-		dataMap["Action"] = evt.Action
-		dataMap["FromFullSync"] = evt.FromFullSync
-		postMap["data"] = dataMap
+		// postMap has no "data" key at this point, so asserting it as a map
+		// panics the whole process whenever a chat is (un)archived on the phone.
+		// Build the payload map directly instead.
+		postMap["data"] = map[string]interface{}{
+			"JID":          evt.JID,
+			"Timestamp":    evt.Timestamp,
+			"Action":       evt.Action,
+			"FromFullSync": evt.FromFullSync,
+		}
 
 		mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Chat archived", mycli.userID)
 	case *events.HistorySync:


### PR DESCRIPTION
`myEventHandler` builds `postMap` without a `"data"` key, so the `*events.Archive` case asserting `postMap["data"].(map[string]interface{})` (pkg/whatsmeow/service/whatsmeow.go:1820) panics the whole process whenever a chat is archived or unarchived on the paired phone.

Every other case that reads `postMap["data"]` guards the key first (Message, Receipt, etc.) — Archive was the only one missing the guard. This builds the data payload map directly, preserving the exact webhook shape.

**How to reproduce:** pair an instance, archive any chat on the phone → the process dies with `panic: interface conversion: interface {} is nil, not map[string]interface {}`.

## Summary by Sourcery

Bug Fixes:
- Fix crash on chat archive/unarchive events caused by unchecked type assertion on the webhook data payload.