### PR TITLE
fix(history): deliver on-demand history-sync and deepen on-link backfill

### DIFF
--- a/pkg/chat/handler/chat_handler.go
+++ b/pkg/chat/handler/chat_handler.go
@@ -319,7 +319,7 @@ func (c *chatHandler) HistorySyncRequest(ctx *gin.Context) {
 		return
 	}
 
-	resp, err := c.chatService.HistorySyncRequest(data, instance)
+	resp, err := c.chatService.HistorySyncRequest(ctx.Request.Context(), data, instance)
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/pkg/chat/service/chat_service.go
+++ b/pkg/chat/service/chat_service.go
@@ -234,7 +234,12 @@ func (c *chatService) HistorySyncRequest(data *HistorySyncRequestStruct, instanc
 
 	histRequest := client.BuildHistorySyncRequest(&messageInfo, data.Count)
 
-	res, err := client.SendMessage(context.Background(), messageInfo.Chat, histRequest, whatsmeow.SendRequestExtra{Peer: true})
+	// On-demand history-sync requests must be sent to our OWN JID as a peer message, not to the
+	// contact. SendPeerMessage does exactly that (getOwnID().ToNonAD() + Peer:true). Sending it to
+	// messageInfo.Chat (the contact) fails with "no signal session established" and never returns
+	// history. whatsmeow's BuildHistorySyncRequest doc: "The built message can be sent using
+	// Client.SendPeerMessage." The target chat/cursor is already encoded inside histRequest.
+	res, err := client.SendPeerMessage(context.Background(), histRequest)
 	if err != nil {
 		c.loggerWrapper.GetLogger(instance.Id).LogError("[%s] error history sync request: %v", instance.Id, err)
 		return nil, err

--- a/pkg/chat/service/chat_service.go
+++ b/pkg/chat/service/chat_service.go
@@ -21,7 +21,7 @@ type ChatService interface {
 	ChatUnarchive(data *BodyStruct, instance *instance_model.Instance) (string, error)
 	ChatMute(data *BodyStruct, instance *instance_model.Instance) (string, error)
 	ChatUnmute(data *BodyStruct, instance *instance_model.Instance) (string, error)
-	HistorySyncRequest(data *HistorySyncRequestStruct, instance *instance_model.Instance) (*whatsmeow.SendResponse, error)
+	HistorySyncRequest(ctx context.Context, data *HistorySyncRequestStruct, instance *instance_model.Instance) (*whatsmeow.SendResponse, error)
 }
 
 type chatService struct {
@@ -216,7 +216,7 @@ func (c *chatService) ChatUnmute(data *BodyStruct, instance *instance_model.Inst
 	return ts.String(), nil
 }
 
-func (c *chatService) HistorySyncRequest(data *HistorySyncRequestStruct, instance *instance_model.Instance) (*whatsmeow.SendResponse, error) {
+func (c *chatService) HistorySyncRequest(ctx context.Context, data *HistorySyncRequestStruct, instance *instance_model.Instance) (*whatsmeow.SendResponse, error) {
 	client, err := c.ensureClientConnected(instance.Id)
 	if err != nil {
 		return nil, err
@@ -239,7 +239,8 @@ func (c *chatService) HistorySyncRequest(data *HistorySyncRequestStruct, instanc
 	// messageInfo.Chat (the contact) fails with "no signal session established" and never returns
 	// history. whatsmeow's BuildHistorySyncRequest doc: "The built message can be sent using
 	// Client.SendPeerMessage." The target chat/cursor is already encoded inside histRequest.
-	res, err := client.SendPeerMessage(context.Background(), histRequest)
+	// Uses the caller's context so the request can be cancelled / time-bounded.
+	res, err := client.SendPeerMessage(ctx, histRequest)
 	if err != nil {
 		c.loggerWrapper.GetLogger(instance.Id).LogError("[%s] error history sync request: %v", instance.Id, err)
 		return nil, err

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -301,6 +301,15 @@ func (w whatsmeowService) ForceUpdateJid(instanceId string, number string) error
 	return nil
 }
 
+// History-sync depth requested from the phone when a device links (DeviceProps.HistorySyncConfig).
+// Generous defaults so a newly linked device receives the full available history; tune here if
+// bandwidth/storage is a concern.
+const (
+	historyFullSyncDaysLimit   = 3650 // ~10 years
+	historyFullSyncSizeMbLimit = 2048 // 2 GB
+	historyStorageQuotaMb      = 2048 // 2 GB
+)
+
 func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("Starting websocket connection to Whatsapp for user '%s'", cd.Instance.Id)
@@ -376,11 +385,12 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	store.DeviceProps.RequireFullSync = proto.Bool(true)
 	// RequireFullSync alone still yields a shallow/uneven backfill because the phone falls back to
 	// conservative defaults. Explicitly request a deep on-link HistorySync window so newly linked
-	// devices receive the full available message history.
+	// devices receive the full available message history. Values are named constants so deployments
+	// can tune history depth / resource usage in one place.
 	store.DeviceProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{
-		FullSyncDaysLimit:   proto.Uint32(3650),
-		FullSyncSizeMbLimit: proto.Uint32(2048),
-		StorageQuotaMb:      proto.Uint32(2048),
+		FullSyncDaysLimit:   proto.Uint32(historyFullSyncDaysLimit),
+		FullSyncSizeMbLimit: proto.Uint32(historyFullSyncSizeMbLimit),
+		StorageQuotaMb:      proto.Uint32(historyStorageQuotaMb),
 	}
 
 	if w.config.WhatsappVersionMajor != 0 && w.config.WhatsappVersionMinor != 0 && w.config.WhatsappVersionPatch != 0 {

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -374,6 +374,14 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	store.DeviceProps.Os = &cd.Instance.OsName
 	store.DeviceProps.RequireFullSync = proto.Bool(true)
+	// RequireFullSync alone still yields a shallow/uneven backfill because the phone falls back to
+	// conservative defaults. Explicitly request a deep on-link HistorySync window so newly linked
+	// devices receive the full available message history.
+	store.DeviceProps.HistorySyncConfig = &waCompanionReg.DeviceProps_HistorySyncConfig{
+		FullSyncDaysLimit:   proto.Uint32(3650),
+		FullSyncSizeMbLimit: proto.Uint32(2048),
+		StorageQuotaMb:      proto.Uint32(2048),
+	}
 
 	if w.config.WhatsappVersionMajor != 0 && w.config.WhatsappVersionMinor != 0 && w.config.WhatsappVersionPatch != 0 {
 		w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("[%s] Setting whatsapp version to %d.%d.%d", cd.Instance.Id, w.config.WhatsappVersionMajor, w.config.WhatsappVersionMinor, w.config.WhatsappVersionPatch)


### PR DESCRIPTION
## Summary
Two small fixes so that message history actually reaches newly linked devices:

1. **On-demand history-sync now delivers.** `HistorySyncRequest` sent the peer request to `messageInfo.Chat` (the contact). Peer messages must be sent to the account's **own** JID — sending to the contact fails with `failed to encrypt peer message ... no signal session established with <device>` and the phone never returns any history. Switched to `client.SendPeerMessage`, which whatsmeow documents as the correct way to send a `BuildHistorySyncRequest` (it targets `getOwnID().ToNonAD()` with `Peer: true`). The target chat/cursor is already encoded inside the built request, so no information is lost.

2. **On-link backfill is now deep.** `RequireFullSync = true` alone still produced a shallow, uneven backfill because the phone falls back to conservative defaults when no `HistorySyncConfig` is provided. Setting an explicit deep window makes a freshly linked device receive the full available history.

## Why
On the current release, after pairing a device:
- The initial HistorySync push only brings a small, uneven slice of recent messages.
- `POST /chat/history-sync` returns `200` but no `HistorySync` (ON_DEMAND) event ever arrives — the request 500s internally with `no signal session established`, and even when a session exists the request is addressed to the wrong JID so the phone has nothing to answer.

Together these make it impossible to backfill a conversation's history through the API.

## Changes
- `pkg/chat/service/chat_service.go` — send the on-demand request via `SendPeerMessage`.
- `pkg/whatsmeow/service/whatsmeow.go` — set `DeviceProps.HistorySyncConfig` (`FullSyncDaysLimit`, `FullSyncSizeMbLimit`, `StorageQuotaMb`).

## Notes
The `FullSyncDaysLimit`/size values are conservative-but-generous defaults; happy to make them configurable via instance settings/env if preferred.

## Summary by Sourcery

Ensure newly linked devices receive complete message history via on-link and on-demand history sync.

Bug Fixes:
- Fix on-demand history sync requests being sent to the contact JID instead of the account’s own JID so that history is actually returned.

Enhancements:
- Configure explicit deep HistorySync parameters (days, size, storage quota) so full history is backfilled to newly linked devices.