### PR TITLE
feat(webhook): allow multiple webhook URLs per instance (fan-out)

### DIFF
--- a/pkg/events/webhook/webhook_producer.go
+++ b/pkg/events/webhook/webhook_producer.go
@@ -2,6 +2,7 @@ package webhook_producer
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -43,11 +44,53 @@ func (p *webhookProducer) Produce(
 	if p.url != "" {
 		go p.sendWebhookWithRetry(p.url, payload, 5, 30*time.Second, userID)
 	}
-	if webhookUrl != "" {
-		go p.sendWebhookWithRetry(webhookUrl, payload, 5, 30*time.Second, userID)
+
+	// Support multiple webhook URLs per instance. The instance Webhook field
+	// may contain several URLs (separated by newline, comma or semicolon, or a
+	// JSON array). The SAME request is delivered to each address. Fully
+	// backward compatible with a single URL.
+	for _, url := range splitWebhookURLs(webhookUrl) {
+		u := url
+		go p.sendWebhookWithRetry(u, payload, 5, 30*time.Second, userID)
 	}
 
 	return nil
+}
+
+// splitWebhookURLs splits the instance webhook string into one or more URLs.
+// It accepts a JSON array (["https://a","https://b"]) OR a list separated by
+// newline / comma / semicolon. It drops duplicates, empty entries and the
+// "disabled" marker.
+func splitWebhookURLs(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "disabled" {
+		return nil
+	}
+
+	var parts []string
+	if strings.HasPrefix(raw, "[") {
+		var arr []string
+		if err := json.Unmarshal([]byte(raw), &arr); err == nil {
+			parts = arr
+		}
+	}
+	if parts == nil {
+		parts = strings.FieldsFunc(raw, func(r rune) bool {
+			return r == '\n' || r == '\r' || r == ',' || r == ';'
+		})
+	}
+
+	out := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || p == "disabled" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
 }
 
 func (p *webhookProducer) sendWebhookWithRetry(url string, body []byte, maxRetries int, retryInterval time.Duration, userID string) {


### PR DESCRIPTION
## Description
The instance `Webhook` field can now hold multiple URLs. The producer delivers the
SAME event request to every address (each with its own retry). Accepted formats:
newline / comma / semicolon separated, or a JSON array. Duplicates, empty entries
and the `"disabled"` marker are ignored.

No schema change: the `Webhook` column stays a `string`; only
`pkg/events/webhook/webhook_producer.go` was touched (new `splitWebhookURLs`
helper). Fully backward compatible — a single URL behaves exactly as before. The
global webhook (`config.WebhookUrl`) keeps being sent in parallel.

## Related Issue
N/A

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

## Screenshots (if applicable)
N/A — backend only.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Additional Notes
Single-file change. `Produce` now fans the same payload out to every URL returned
by `splitWebhookURLs`, instead of a single `webhookUrl`.

## Summary by Sourcery

New Features:
- Allow an instance webhook configuration to specify multiple URLs, each receiving the same event payload with independent retries.