### PR TITLE
fix: skip NATS connection when URL is empty

### DIFF
--- a/pkg/events/nats/nats_producer.go
+++ b/pkg/events/nats/nats_producer.go
@@ -5,6 +5,7 @@ import (
 	logger_wrapper "github.com/evolution-foundation/evolution-go/pkg/logger"
 	"github.com/gomessguii/logger"
 	"github.com/nats-io/nats.go"
+	"strings"
 )
 
 type natsProducer struct {
@@ -20,6 +21,15 @@ func NewNatsProducer(
 	natsGlobalEvents []string,
 	loggerWrapper *logger_wrapper.LoggerManager,
 ) producer_interfaces.Producer {
+	if strings.TrimSpace(url) == "" {
+		return &natsProducer{
+			conn:              nil,
+			natsGlobalEnabled: false,
+			natsGlobalEvents:  nil,
+			loggerWrapper:     loggerWrapper,
+		}
+	}
+
 	conn, err := nats.Connect(url)
 	if err != nil {
 		logger.LogError("Failed to connect to NATS: %v", err)

--- a/pkg/events/nats/nats_producer_test.go
+++ b/pkg/events/nats/nats_producer_test.go
@@ -1,0 +1,16 @@
+package nats_producer
+
+import "testing"
+
+func TestNewNatsProducerDoesNotConnectWithoutURL(t *testing.T) {
+	producer, ok := NewNatsProducer("  ", false, nil, nil).(*natsProducer)
+	if !ok {
+		t.Fatal("constructor returned an unexpected producer type")
+	}
+	if producer.conn != nil {
+		t.Fatal("NATS connection must stay nil when NATS_URL is empty")
+	}
+	if producer.natsGlobalEnabled {
+		t.Fatal("NATS global publishing must stay disabled without a URL")
+	}
+}

--- a/pkg/events/nats/nats_producer_test.go
+++ b/pkg/events/nats/nats_producer_test.go
@@ -3,14 +3,29 @@ package nats_producer
 import "testing"
 
 func TestNewNatsProducerDoesNotConnectWithoutURL(t *testing.T) {
-	producer, ok := NewNatsProducer("  ", false, nil, nil).(*natsProducer)
-	if !ok {
-		t.Fatal("constructor returned an unexpected producer type")
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"Empty URL", ""},
+		{"Whitespace URL", "  "},
 	}
-	if producer.conn != nil {
-		t.Fatal("NATS connection must stay nil when NATS_URL is empty")
-	}
-	if producer.natsGlobalEnabled {
-		t.Fatal("NATS global publishing must stay disabled without a URL")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			producer, ok := NewNatsProducer(tt.url, true, []string{"event1"}, nil).(*natsProducer)
+			if !ok {
+				t.Fatal("constructor returned an unexpected producer type")
+			}
+			if producer.conn != nil {
+				t.Fatal("NATS connection must stay nil when NATS_URL is empty")
+			}
+			if producer.natsGlobalEnabled {
+				t.Fatal("NATS global publishing must stay disabled without a URL")
+			}
+			if producer.natsGlobalEvents != nil {
+				t.Fatal("natsGlobalEvents must be nil when NATS_URL is empty")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing
- [ ] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced

## Screenshots (if applicable)

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Additional Notes

## Summary by Sourcery

Skip establishing a NATS connection when no URL is provided and ensure producer is disabled in that case.

Bug Fixes:
- Avoid creating a NATS connection when the configured URL is empty or whitespace-only.

Tests:
- Add a unit test verifying that the NATS producer does not connect and remains disabled when initialized without a URL.