### PR TITLE
feat(send): support view-once media on /send/media

### DIFF
--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -117,6 +117,7 @@ type MediaStruct struct {
 	FormatJid       *bool        `json:"formatJid,omitempty"`
 	Quoted          QuotedStruct `json:"quoted"`
 	ForwardingScore *uint32      `json:"forwardingScore,omitempty"`
+	ViewOnce        bool         `json:"viewOnce"`
 }
 
 type PollStruct struct {
@@ -1186,6 +1187,24 @@ func (s *sendService) sendMediaFileWithRetry(data *MediaStruct, fileData []byte,
 			return nil, errors.New("invalid media type")
 		}
 
+		// view-once: when requested, flag the media so it disappears after the recipient opens it
+		// once (image, video and voice/PTV support it; documents do not). Additive — without the
+		// flag the media is a normal message, exactly as before.
+		if data.ViewOnce {
+			if media.ImageMessage != nil {
+				media.ImageMessage.ViewOnce = proto.Bool(true)
+			}
+			if media.VideoMessage != nil {
+				media.VideoMessage.ViewOnce = proto.Bool(true)
+			}
+			if media.AudioMessage != nil {
+				media.AudioMessage.ViewOnce = proto.Bool(true)
+			}
+			if media.PtvMessage != nil {
+				media.PtvMessage.ViewOnce = proto.Bool(true)
+			}
+		}
+
 		message, err := s.SendMessage(instance, media, mediaType, &SendDataStruct{
 			Id:              data.Id,
 			Number:          data.Number,
@@ -1488,6 +1507,24 @@ func (s *sendService) sendMediaUrlWithRetry(data *MediaStruct, instance *instanc
 			mediaType = "DocumentMessage"
 		default:
 			return nil, errors.New("invalid media type")
+		}
+
+		// view-once: when requested, flag the media so it disappears after the recipient opens it
+		// once (image, video and voice/PTV support it; documents do not). Additive — without the
+		// flag the media is a normal message, exactly as before.
+		if data.ViewOnce {
+			if media.ImageMessage != nil {
+				media.ImageMessage.ViewOnce = proto.Bool(true)
+			}
+			if media.VideoMessage != nil {
+				media.VideoMessage.ViewOnce = proto.Bool(true)
+			}
+			if media.AudioMessage != nil {
+				media.AudioMessage.ViewOnce = proto.Bool(true)
+			}
+			if media.PtvMessage != nil {
+				media.PtvMessage.ViewOnce = proto.Bool(true)
+			}
 		}
 
 		messageStart := time.Now()


### PR DESCRIPTION
## What

Adds an optional `viewOnce` boolean to the media send body (`MediaStruct`), used by `POST /send/media` and `POST /send/media/file`. When `true`, the media is flagged as **view-once** (disappears after the recipient opens it once).

## Why

The `waE2E` media protos (`ImageMessage`, `VideoMessage`, `AudioMessage`) already expose a `ViewOnce` field, but the send endpoints don't let callers set it — so it's currently impossible to send a view-once photo/video/voice through Evolution Go, even though the Baileys-based Evolution API supports it. This closes that parity gap.

## Change

- `MediaStruct` gains `ViewOnce bool \`json:"viewOnce"\`` (defaults to `false` → existing callers unaffected).
- In both media builders (`sendMediaFileWithRetry` and `sendMediaUrlWithRetry`), after the media message is built, a small additive block sets `ViewOnce = proto.Bool(true)` on the image / video / audio / PTV proto when requested. Documents are intentionally left out (WhatsApp doesn't support view-once documents).

```jsonc
POST /send/media
{ "number": "5521...", "type": "image", "url": "https://...", "caption": "hi", "viewOnce": true }
```

## Notes

- Purely additive; no behavior change when `viewOnce` is omitted/false.
- Swagger request-body docs weren't regenerated locally (no Go toolchain on my side) — happy to run `swag init` or adjust if the CI expects it. The functional change is self-contained in `send_service.go`.

## Summary by Sourcery

Add support for marking outbound media messages as view-once in the send media service.

New Features:
- Allow clients to set a viewOnce flag on media send requests via the MediaStruct.
- Enable view-once behavior for image, video, audio, and PTV messages sent through /send/media and /send/media/file.