### PR TITLE
fix(instance): prevent GetQr from disconnecting active logged-in session

### DIFF
--- a/pkg/instance/service/instance_service.go
+++ b/pkg/instance/service/instance_service.go
@@ -407,12 +407,20 @@ func (i instances) GetQr(instance *instance_model.Instance) (*QrcodeStruct, erro
 	logger := i.loggerWrapper.GetLogger(instance.Id)
 	client := i.clientPointer[instance.Id]
 
-	// Se não há cliente ou o cliente está logado, precisamos iniciar um novo cliente
-	if client == nil || client.IsLoggedIn() {
-		if client != nil && client.IsLoggedIn() {
-			logger.LogInfo("[%s] Client is logged in, starting new instance for QR code", instance.Id)
-		} else {
+	// Se o cliente já está logado, NÃO reiniciar — apenas informar. Chamar StartInstance
+	// numa sessão logada derruba o whatsmeow (Disconnected → novo QR), o que pode ser
+	// disparado por polling do frontend logo após PairSuccess, quebrando a conexão.
+	if client != nil && client.IsLoggedIn() {
+		logger.LogInfo("[%s] Client is already logged in — returning 'session already logged in' (StartInstance skipped to avoid disconnect)", instance.Id)
+		return nil, fmt.Errorf("session already logged in")
+	}
+
+	// Se não há cliente OU cliente sem sessão logada, iniciar/reiniciar para gerar QR
+	if client == nil || (!client.IsConnected() && !client.IsLoggedIn()) {
+		if client == nil {
 			logger.LogInfo("[%s] No client found, starting new instance for QR code", instance.Id)
+		} else {
+			logger.LogInfo("[%s] Client exists but not connected/logged, restarting for QR code", instance.Id)
 		}
 
 		// Iniciar nova instância para gerar QR code


### PR DESCRIPTION
## Problema

Quando `GET /instance/qr` é chamado em uma instância que já está logada (`client.IsLoggedIn() == true`), a implementação atual do `GetQr` chama `whatsmeowService.StartInstance()` mesmo assim, derrubando o cliente whatsmeow ativo e forçando um novo pareamento.

### Reprodução

1. Parear uma nova instância via QR Code — receber `PairSuccess`
2. Logo após o `PairSuccess`, o whatsmeow entra em `Connected: true, LoggedIn: false` por ~5–15 s enquanto faz o history sync inicial
3. Qualquer frontend fazendo polling em `GET /instance/qr` durante esse intervalo (muito comum — a maioria dos managers faz polling a cada 3–5 s para detectar a conexão) cai no branch com bug
4. Como `IsLoggedIn()` retorna `true` em qualquer momento após o login completar, o handler chama `StartInstance()` → whatsmeow desconecta → novo QR code é emitido
5. Usuário vê a sessão "morrer" segundos após parear com sucesso

### Sequência de webhooks observada

```
13:32:48  PairSuccess           # pareamento OK
13:33:01-04  HistorySync (x5)   # whatsmeow sincronizando (LoggedIn:false)
13:33:09  Disconnected          # GET /instance/qr disparou StartInstance
13:33:13  Connected             # whatsmeow reconectando
13:33:14  QRCode (4/5)          # sessão perdida, novo QR
```

Isso não ocorre ao usar o próprio manager web do Evolution-Go, porque ele usa SSE para mudanças de status em vez de fazer polling em `/instance/qr`.

### Causa raiz

`pkg/instance/service/instance_service.go` no método `GetQr`:

```go
// Se não há cliente ou o cliente está logado, precisamos iniciar um novo cliente
if client == nil || client.IsLoggedIn() {   // <-- também entra quando LOGADO
    ...
    err := i.whatsmeowService.StartInstance(instance.Id)   // <-- derruba o cliente ativo
    time.Sleep(3 * time.Second)
    ...
}
```

O comentário ("iniciar um novo cliente") revela que a intenção original era (re)iniciar quando não houvesse cliente. Mas a condição também dispara para clientes logados, provavelmente para forçar um novo QR quando o chamador quer explicitamente re-parear. Esse caminho deveria ser um opt-in explícito, não o comportamento padrão do `GetQr`.

## Correção

Separar os dois casos:

- Se `client.IsLoggedIn()` → retorna `"session already logged in"` imediatamente, sem tocar no `StartInstance`. Chamadores que queiram forçar re-pareamento podem fazer logout antes via `DELETE /instance/logout` ou usar `POST /instance/forcereconnect`.
- Se `client == nil` ou `!client.IsConnected() && !client.IsLoggedIn()` → inicia a instância como antes.
- Caso contrário (cliente existe, não conectado, não logado) → aguarda um QR code existente.

```go
if client != nil && client.IsLoggedIn() {
    logger.LogInfo("[%s] Client is already logged in — returning 'session already logged in' (StartInstance skipped to avoid disconnect)", instance.Id)
    return nil, fmt.Errorf("session already logged in")
}

if client == nil || (!client.IsConnected() && !client.IsLoggedIn()) {
    // caminho existente do StartInstance
}
```

Comportamento quando o chamador faz polling em `/instance/qr` numa instância logada:

- **Antes:** whatsmeow desconectado, novo QR emitido, sessão perdida
- **Depois:** HTTP 400 `"session already logged in"` (já era o comportamento documentado da segunda checagem de `IsLoggedIn` dentro do branch — essa correção apenas faz o short-circuit antes da chamada destrutiva ao `StartInstance`)

## Impacto

- **Sem mudança de API** — o payload de resposta para instâncias logadas já é `"session already logged in"`; essa correção apenas torna a resposta consistente independentemente do timing e remove o efeito colateral
- **Sem mudança de configuração** necessária
- **Frontends** que faziam polling em `/instance/qr` para detectar conexão agora podem fazer isso com segurança, sem risco de desconectar a instância que acabaram de parear

## Testado

- Pareada uma nova instância com o frontend fazendo polling em `/instance/qr` a cada 4 s
- **Antes da correção:** sessão caiu ~15 s após o `PairSuccess`
- **Depois da correção:** sessão manteve-se ativa, HistorySync foi concluído, instância funcional

---

## Summary by Sourcery

Prevent QR retrieval from restarting already logged-in WhatsApp instances, avoiding unintended disconnects during polling.

Bug Fixes:
- Return a 'session already logged in' error from GetQr without restarting the instance when a client is already logged in, preventing forced re-pairing triggered by frontend polling.
- Restrict instance restarts for QR generation to cases where there is no client or the client is neither connected nor logged in, avoiding unnecessary disconnects of active sessions.