### PR TITLE
fix: recover undecryptable messages via AutomaticMessageRerequestFrom…

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -463,6 +463,10 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	client.EnableAutoReconnect = false
 	client.AutoTrustIdentity = true
+	// FIX (MEGA): recupera mensagens indecifráveis (1ª msg de leads CTWA) pedindo o reenvio
+	// ao próprio telefone (device primário). Sem isso, UndecryptableMessage é descartada sem
+	// webhook. whatsmeow espera RequestFromPhoneDelay (~5s) o remetente reenviar; senão pede ao phone.
+	client.AutomaticMessageRerequestFromPhone = true
 
 	mycli := &MyClient{
 		service:            &w,


### PR DESCRIPTION
…Phone

Companion/multi-device bots drop the FIRST message from new CTWA/ad leads when it fails to decrypt: whatsmeow emits UndecryptableMessage and the event handler skips the webhook (only view_once / ID 66-67 are handled), with no retry. Setting AutomaticMessageRerequestFromPhone makes whatsmeow ask the primary phone to resend after RequestFromPhoneDelay (~5s), so the message is recovered and dispatched as a normal Message webhook.

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing
- [ ] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced

## Screenshots (if applicable)

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Additional Notes

## Summary by Sourcery

Bug Fixes:
- Ensure initial CTWA/ad lead messages that fail decryption are retried via the primary phone instead of being silently discarded.