### PR TITLE
fix: panic on Archive event due to unchecked type assertion

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1694,12 +1694,15 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		doWebhook = true
 		postMap["event"] = "Archive"
 
-		dataMap := postMap["data"].(map[string]interface{})
-		dataMap["JID"] = evt.JID
-		dataMap["Timestamp"] = evt.Timestamp
-		dataMap["Action"] = evt.Action
-		dataMap["FromFullSync"] = evt.FromFullSync
-		postMap["data"] = dataMap
+		// postMap has no "data" key at this point, so asserting it as a map
+		// panics the whole process whenever a chat is (un)archived on the phone.
+		// Build the payload map directly instead.
+		postMap["data"] = map[string]interface{}{
+			"JID":          evt.JID,
+			"Timestamp":    evt.Timestamp,
+			"Action":       evt.Action,
+			"FromFullSync": evt.FromFullSync,
+		}
 
 		mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Chat archived", mycli.userID)
 	case *events.HistorySync:


### PR DESCRIPTION
`myEventHandler` builds `postMap` without a `"data"` key, so the `*events.Archive` case asserting `postMap["data"].(map[string]interface{})` (pkg/whatsmeow/service/whatsmeow.go:1820) panics the whole process whenever a chat is archived or unarchived on the paired phone.

Every other case that reads `postMap["data"]` guards the key first (Message, Receipt, etc.) — Archive was the only one missing the guard. This builds the data payload map directly, preserving the exact webhook shape.

**How to reproduce:** pair an instance, archive any chat on the phone → the process dies with `panic: interface conversion: interface {} is nil, not map[string]interface {}`.

---

**Retargeted to `develop`** (replaces #125), as requested by @iagocotta in https://github.com/evolution-foundation/evolution-go/pull/128#issuecomment-5180476581.

Note that `main` and `develop` have **no common ancestor** — the GitHub API refuses to compare them (`No common ancestor between main and develop`) — so the base branch of the original PR could not simply be edited. This branch was created from `develop` and the commit cherry-picked onto it.

Verified on this branch: `go build ./...` and `go vet ./...` both pass.

## Summary by Sourcery

Bug Fixes:
- Fix Archive event handling that assumed an existing data payload and crashed on chat archive/unarchive.