### PR TITLE
fix: recover zombie connections on KeepAliveTimeout

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1865,6 +1865,35 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 				mycli.loggerWrapper.GetLogger(instanceID).LogError("[%s] Failed to restart instance: %v", instanceID, err)
 			}
 		}(mycli.userID)
+	case *events.KeepAliveTimeout:
+		doWebhook = true
+		postMap["event"] = "KeepAliveTimeout"
+		postMap["data"] = map[string]interface{}{
+			"ErrorCount":  evt.ErrorCount,
+			"LastSuccess": evt.LastSuccess,
+		}
+		mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Keepalive ping timed out (%d consecutive, last success: %s)", mycli.userID, evt.ErrorCount, evt.LastSuccess.Format(time.RFC3339))
+
+		// With EnableAutoReconnect disabled, a TCP connection that silently dies
+		// keeps timing out keepalives forever without ever emitting
+		// events.Disconnected — the instance stays "connected" but is a zombie.
+		// whatsmeow's own docs suggest using this event to force a faster
+		// disconnect+reconnect, so after 3 consecutive timeouts restart the
+		// instance through the same path the Disconnected handler uses. Exact
+		// match keeps counts 4, 5, ... from piling up restarts while one is
+		// already underway.
+		if evt.ErrorCount == 3 {
+			go func(instanceID string) {
+				mycli.loggerWrapper.GetLogger(instanceID).LogWarn("[%s] 3 consecutive keepalive timeouts, restarting instance", instanceID)
+				if err := mycli.service.ReconnectClient(instanceID); err != nil {
+					mycli.loggerWrapper.GetLogger(instanceID).LogError("[%s] Failed to restart instance: %v", instanceID, err)
+				}
+			}(mycli.userID)
+		}
+	case *events.KeepAliveRestored:
+		doWebhook = true
+		postMap["event"] = "KeepAliveRestored"
+		mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Keepalive pings restored", mycli.userID)
 	case *events.LabelEdit:
 		doWebhook = true
 		postMap["event"] = "LabelEdit"
@@ -2092,7 +2121,7 @@ func (w *whatsmeowService) CallWebhook(instance *instance_model.Instance, queueN
 			w.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Event received of type %s", instance.Id, eventType)
 			w.sendToQueueOrWebhook(instance, queueName, jsonData)
 		}
-	case "Connected", "PairSuccess", "TemporaryBan", "LoggedOut", "ConnectFailure", "Disconnected":
+	case "Connected", "PairSuccess", "TemporaryBan", "LoggedOut", "ConnectFailure", "Disconnected", "KeepAliveTimeout", "KeepAliveRestored":
 		if contains(subscriptions, "CONNECTION") {
 			w.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Event received of type %s", instance.Id, eventType)
 			w.sendToQueueOrWebhook(instance, queueName, jsonData)
@@ -2370,7 +2399,7 @@ func (w *whatsmeowService) SendToGlobalQueues(eventType string, payload []byte, 
 				globalEventType = "CHAT_PRESENCE"
 			case "CallOffer", "CallAccept", "CallTerminate", "CallOfferNotice", "CallRelayLatency":
 				globalEventType = "CALL"
-			case "Connected", "PairSuccess", "TemporaryBan", "LoggedOut", "ConnectFailure", "Disconnected":
+			case "Connected", "PairSuccess", "TemporaryBan", "LoggedOut", "ConnectFailure", "Disconnected", "KeepAliveTimeout", "KeepAliveRestored":
 				globalEventType = "CONNECTION"
 			case "LabelEdit", "LabelAssociationChat", "LabelAssociationMessage":
 				globalEventType = "LABEL"
@@ -2428,7 +2457,7 @@ func (w *whatsmeowService) SendToGlobalQueues(eventType string, payload []byte, 
 			globalEventType = "CHAT_PRESENCE"
 		case "CallOffer", "CallAccept", "CallTerminate", "CallOfferNotice", "CallRelayLatency":
 			globalEventType = "CALL"
-		case "Connected", "PairSuccess", "TemporaryBan", "LoggedOut", "ConnectFailure", "Disconnected":
+		case "Connected", "PairSuccess", "TemporaryBan", "LoggedOut", "ConnectFailure", "Disconnected", "KeepAliveTimeout", "KeepAliveRestored":
 			globalEventType = "CONNECTION"
 		case "LabelEdit", "LabelAssociationChat", "LabelAssociationMessage":
 			globalEventType = "LABEL"


### PR DESCRIPTION
With `EnableAutoReconnect` disabled (whatsmeow.go:464), a TCP connection that dies silently (no FIN/RST from the server — NAT timeout, network flap) never emits `events.Disconnected`: keepalive pings just keep timing out and the instance stays flagged as connected while being unable to send or receive. Only a manual restart fixes it. whatsmeow's own docs on `KeepAliveTimeout` suggest exactly this: *"Clients may use this event to decide to force a disconnect+reconnect faster."*

This handles `KeepAliveTimeout` and `KeepAliveRestored`:
- both are forwarded to the `CONNECTION` webhook subscription so operators can observe socket health;
- after 3 consecutive timeouts the instance is restarted through the same non-blocking `ReconnectClient` path the `Disconnected` handler already uses (exact-match on the count so an ongoing restart isn't duplicated).

We run multiple production instances behind this and it eliminated our "zombie instance" incidents (instance reported connected, no traffic flowing, external watchdog required).

---

**Retargeted to `develop`** (replaces #126), as requested by @iagocotta in https://github.com/evolution-foundation/evolution-go/pull/128#issuecomment-5180476581.

Note that `main` and `develop` have **no common ancestor** — the GitHub API refuses to compare them (`No common ancestor between main and develop`) — so the base branch of the original PR could not simply be edited. This branch was created from `develop` and the commit cherry-picked onto it.

Verified on this branch: `go build ./...` and `go vet ./...` both pass.

## Summary by Sourcery

Handle keepalive timeout and restoration events to recover zombie connections and expose socket health via connection webhooks.

Bug Fixes:
- Restart instances after three consecutive keepalive timeouts to recover silently dead TCP connections when auto-reconnect is disabled.

Enhancements:
- Forward KeepAliveTimeout and KeepAliveRestored events to CONNECTION webhooks and global queues for better observability of connection health.