### PR TITLE
fix: canonicalize JIDs in GetAvatar, DeleteMessageEveryone and EditMessage

### DIFF
--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -375,6 +375,10 @@ func (m *messageService) DeleteMessageEveryone(data *MessageStruct, instance *in
 		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error validating message fields", instance.Id)
 		return "", "", errors.New("invalid phone number")
 	}
+	// The chat JID lands inside the revoke's protocolMessage Key: with the "+"
+	// prefix CreateJID adds, receiving devices look up a chat that doesn't
+	// exist and silently ignore the revoke. See utils.CanonicalJID.
+	recipient = utils.CanonicalJID(recipient)
 
 	m.loggerWrapper.GetLogger(instance.Id).LogInfo("Revoking message %s from %s", data.MessageID, recipient)
 
@@ -403,6 +407,9 @@ func (m *messageService) EditMessage(data *EditMessageStruct, instance *instance
 		m.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error validating message fields", instance.Id)
 		return "", "", errors.New("invalid phone number")
 	}
+	// Same as DeleteMessageEveryone: the JID lands inside the edit's
+	// protocolMessage Key, so the "+" prefix makes recipients ignore it.
+	recipient = utils.CanonicalJID(recipient)
 
 	resp, err := client.SendMessage(
 		context.Background(),

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -335,6 +335,10 @@ func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.
 	if !ok {
 		return nil, errors.New("invalid phone number")
 	}
+	// GetProfilePictureInfo runs a usync IQ against the JID as-is; the "+"
+	// prefix CreateJID adds to phone numbers makes it query a nonexistent user
+	// and time out (~75s). See utils.CanonicalJID.
+	jid = utils.CanonicalJID(jid)
 
 	u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Requesting avatar for JID: %s, Preview: %v", instance.Id, jid, data.Preview)
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -636,3 +636,10 @@ func PrepareNumberForWhatsAppCheck(phone string, formatJid bool) (string, error)
 	}
 	return numbers[0], nil
 }
+
+// CanonicalJID normalizes a JID user part by stripping the leading "+" that
+// some clients include, so lookups and comparisons match the stored form.
+func CanonicalJID(jid whatsmeow_types.JID) whatsmeow_types.JID {
+	jid.User = strings.TrimPrefix(jid.User, "+")
+	return jid
+}


### PR DESCRIPTION
`CreateJID` intentionally prefixes phone numbers with `+` (`+55...@s.whatsapp.net`). Message sending tolerates it because whatsmeow normalizes the JID during usync/device resolution, and the raw-node paths (typing, receipts, reactions) already strip it via `utils.CanonicalJID` — but three paths still use the prefixed JID as-is:

- **GetAvatar**: `GetProfilePictureInfo` runs a usync IQ against the JID, querying a nonexistent `+...` user and timing out after ~75s (`info query timed out`) instead of returning the picture.
- **DeleteMessageEveryone / EditMessage**: the JID lands inside the `protocolMessage` Key of the revoke/edit, so receiving devices look up a chat named `+...` that doesn't exist and silently ignore the operation.

Apply `utils.CanonicalJID` right after `ParseJID` in all three, matching what the send/receipt paths already do. No-op for group and `@lid` JIDs (their `CreateJID` paths never add the prefix).

---

**Retargeted to `develop`** (replaces #130), as requested by @iagocotta in https://github.com/evolution-foundation/evolution-go/pull/128#issuecomment-5180476581.

Note that `main` and `develop` have **no common ancestor** — the GitHub API refuses to compare them (`No common ancestor between main and develop`) — so the base branch of the original PR could not simply be edited. This branch was created from `develop` and the commit cherry-picked onto it.

`utils.CanonicalJID` does not exist on `develop` (it is only on `main`), so the 3-line helper is included in this PR.

Verified on this branch: `go build ./...` and `go vet ./...` both pass.

## Summary by Sourcery

Canonicalize JIDs in user and message operations to ensure WhatsApp lookups and protocol messages target the correct chats.

Bug Fixes:
- Normalize recipient JIDs in DeleteMessageEveryone so revoke operations are applied instead of being silently ignored by recipients.
- Normalize recipient JIDs in EditMessage so edits are delivered correctly rather than being ignored due to mismatched chat identifiers.
- Canonicalize JIDs in GetAvatar so profile picture lookups query existing users and no longer time out.

Enhancements:
- Introduce a shared CanonicalJID helper to standardize JID normalization across the codebase.