### PR TITLE
fix(sticker): send WebP stickers as-is instead of re-encoding them

### DIFF
--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -1568,9 +1568,9 @@ func (s *sendService) SendSticker(data *StickerStruct, instance *instance_model.
 	var filedata []byte
 
 	if strings.HasPrefix(data.Sticker, "http") {
-		webpData, err := stickerWebP(data.Sticker)
+		webpData, err := stickerWebP(context.Background(), data.Sticker)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert image to WebP: %v", err)
+			return nil, fmt.Errorf("failed to prepare sticker payload: %v", err)
 		}
 
 		filedata = webpData

--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -1568,7 +1568,7 @@ func (s *sendService) SendSticker(data *StickerStruct, instance *instance_model.
 	var filedata []byte
 
 	if strings.HasPrefix(data.Sticker, "http") {
-		webpData, err := convertToWebP(data.Sticker)
+		webpData, err := stickerWebP(data.Sticker)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert image to WebP: %v", err)
 		}
@@ -1591,6 +1591,7 @@ func (s *sendService) SendSticker(data *StickerStruct, instance *instance_model.
 		FileEncSHA256: uploaded.FileEncSHA256,
 		FileSHA256:    uploaded.FileSHA256,
 		FileLength:    proto.Uint64(uint64(len(filedata))),
+		IsAnimated:    proto.Bool(webpIsAnimated(filedata)),
 	}}
 
 	message, err := s.SendMessage(instance, msg, "StickerMessage", &SendDataStruct{

--- a/pkg/sendMessage/service/sticker_webp.go
+++ b/pkg/sendMessage/service/sticker_webp.go
@@ -16,30 +16,51 @@ package send_service
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"image"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/chai2010/webp"
 )
 
-// maxStickerBytes caps the sticker download. WhatsApp rejects stickers far smaller than this; the
-// limit exists so a hostile URL cannot exhaust the process memory — relevant now that the payload
-// is uploaded rather than decoded, so nothing downstream constrains its size either.
-const maxStickerBytes = 10 << 20 // 10 MiB
+const (
+	// maxStickerBytes caps the sticker download. WhatsApp rejects stickers far smaller than this;
+	// the limit exists so a hostile URL cannot exhaust the process memory — relevant now that the
+	// payload is uploaded rather than decoded, so nothing downstream constrains its size either.
+	maxStickerBytes = 10 << 20 // 10 MiB
+
+	// stickerFetchTimeout bounds the download. The sticker URL is supplied by the API caller and
+	// may point anywhere, so a server that accepts the connection and then stalls would otherwise
+	// hold the goroutine open indefinitely.
+	stickerFetchTimeout = 30 * time.Second
+)
+
+var stickerFetchClient = &http.Client{Timeout: stickerFetchTimeout}
 
 // stickerWebP fetches the sticker URL and returns WebP bytes ready to upload.
 //
 // A source that is already a valid WebP is returned untouched; anything else is decoded and
 // encoded to WebP as before.
-func stickerWebP(url string) ([]byte, error) {
-	resp, err := http.Get(url)
+func stickerWebP(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request for sticker URL: %v", err)
+	}
+	resp, err := stickerFetchClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch image from URL: %v", err)
 	}
 	defer resp.Body.Close()
+
+	// Without this, an HTML error page is read as if it were image data: it fails later, deeper,
+	// with a decode error that says nothing about the URL having answered 404.
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("sticker URL returned HTTP %d", resp.StatusCode)
+	}
 
 	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxStickerBytes+1))
 	if err != nil {

--- a/pkg/sendMessage/service/sticker_webp.go
+++ b/pkg/sendMessage/service/sticker_webp.go
@@ -1,0 +1,91 @@
+package send_service
+
+// Sticker payload handling.
+//
+// `SendSticker` used to run every sticker through `convertToWebP`: fetch the URL, decode with
+// `image.Decode` and re-encode with `webp.Encode(Quality: 80)`. That is wrong whenever the source
+// is already a WebP — which is the case for every sticker that came from WhatsApp itself:
+//
+//  1. Animated stickers cannot be sent at all. The registered decoder (chai2010/webp) only reads
+//     static WebP, so an animated file fails with `webpDecodeRGBA: failed` and the whole send dies.
+//  2. The ones that do go through lose quality for nothing — a perfectly valid WebP is decoded and
+//     re-compressed at 80%.
+//
+// So: if the downloaded bytes are already a valid WebP, they are uploaded untouched. Animation and
+// quality survive, and the conversion path is left to the inputs that actually need it (PNG, JPEG).
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"image"
+	"io"
+	"net/http"
+
+	"github.com/chai2010/webp"
+)
+
+// maxStickerBytes caps the sticker download. WhatsApp rejects stickers far smaller than this; the
+// limit exists so a hostile URL cannot exhaust the process memory — relevant now that the payload
+// is uploaded rather than decoded, so nothing downstream constrains its size either.
+const maxStickerBytes = 10 << 20 // 10 MiB
+
+// stickerWebP fetches the sticker URL and returns WebP bytes ready to upload.
+//
+// A source that is already a valid WebP is returned untouched; anything else is decoded and
+// encoded to WebP as before.
+func stickerWebP(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch image from URL: %v", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxStickerBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read image from URL: %v", err)
+	}
+	if len(raw) > maxStickerBytes {
+		return nil, fmt.Errorf("sticker exceeds %d bytes", maxStickerBytes)
+	}
+
+	if isWebP(raw) {
+		return raw, nil
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode image: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := webp.Encode(&buf, img, &webp.Options{Lossless: false, Quality: 80}); err != nil {
+		return nil, fmt.Errorf("failed to encode image to WebP: %v", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// isWebP reports whether b is a well-formed WebP container.
+//
+// It checks the RIFF magic AND that the declared payload size fits in the buffer. That second
+// check matters specifically because of the passthrough above: the old conversion path rejected a
+// truncated download for free (a truncated file fails to decode), whereas a partial body still
+// carries valid RIFF/WEBP magic and would be uploaded as-is, reaching the recipient broken.
+func isWebP(b []byte) bool {
+	if len(b) < 12 || string(b[0:4]) != "RIFF" || string(b[8:12]) != "WEBP" {
+		return false
+	}
+	// The RIFF size field counts everything after it, i.e. len(file) - 8. Trailing padding is
+	// tolerated (some encoders add it); a payload larger than what we hold means truncation.
+	return int(binary.LittleEndian.Uint32(b[4:8]))+8 <= len(b)
+}
+
+// webpIsAnimated reports whether a WebP container declares animation.
+//
+// Only the extended format (VP8X) can be animated, and bit 0x02 of its flags byte is the
+// declaration — the same ANIMATION_FLAG libwebp uses. Plain VP8/VP8L are static by definition.
+func webpIsAnimated(b []byte) bool {
+	if !isWebP(b) || len(b) < 21 || string(b[12:16]) != "VP8X" {
+		return false
+	}
+	return b[20]&0x02 != 0
+}


### PR DESCRIPTION
### Problem

`SendSticker` runs every sticker through `convertToWebP`: fetch the URL, decode with `image.Decode`, re-encode with `webp.Encode(Quality: 80)`. That is wrong whenever the source is already a WebP — which is every sticker that came from WhatsApp itself.

1. **Animated stickers cannot be sent at all.** The registered decoder (chai2010/webp) only reads static WebP, so an animated file fails and the whole send dies with:
   ```
   failed to convert image to WebP: failed to decode image: webpDecodeRGBA: failed
   ```
2. **The ones that do go through lose quality for nothing** — a perfectly valid WebP is decoded and re-compressed at 80%.

### How often it bites

Measured on a real deployment. We classified the 100 sticker files that had arrived in one instance, by the VP8X animation flag (`flags & 0x02`) and by counting `ANMF` chunks:

| | count |
|---|---|
| animated, 2+ frames | 61 |
| animation flag set, **1 frame only** | 4 |
| PNG (evolution-go converts these on arrival) | 28 |
| static WebP | 9 |

**65 of 100 received stickers could not be re-sent.** Not an edge case — it is the majority of what a support agent can forward back to a customer.

The 4 single-frame ones deserve a mention, because they are the ones that make this look like a product bug rather than a limitation: the file sits in the animated container but does not move, so the user sees a perfectly still sticker being rejected as "animated".

### Change

If the downloaded bytes are already a valid WebP, they are uploaded untouched — animation and quality survive. Non-WebP input (PNG, JPEG) still goes through the conversion path, unchanged.

`StickerMessage.IsAnimated` is now set from the container flags; without it the recipient's client renders the first frame as a still image.

Two defensive details that the passthrough makes necessary:

- **The download is capped** with an `io.LimitReader`. `http.Get` + `io.ReadAll` was unbounded, and now that the payload is uploaded rather than decoded, nothing downstream constrains its size either.
- **`isWebP` validates the declared RIFF size** against the buffer length. The old conversion path rejected a truncated download for free (a truncated file fails to decode); a partial body still carries valid RIFF/WEBP magic and would be uploaded as-is, reaching the recipient broken.

One new file plus two lines at the call site, to keep rebasing cheap.

### Testing

Verified end to end against a live instance: a sticker that previously failed with the error above was sent, delivered and read, with the animation intact on the recipient's device. `go build ./...` and `go vet ./pkg/sendMessage/...` clean on `develop`.

### Relation to #151

@nicolasnovis got here first — #151 (2026-07-31) fixes the same bug the same way, and I only found it after writing this. It is based on `main`, and on #128 @iagocotta asked that PRs target `develop`, which is why this one exists separately rather than as a comment.

**I have no attachment to which one lands.** If #151 is retargeted to `develop`, I will close this and it can carry the fix; the two hardening bits above would then be worth folding in (they are the only substantive difference). Maintainers' call.

## Summary by Sourcery

Handle sticker sending by passing through existing WebP stickers unchanged, while still converting non-WebP images, and mark animated stickers correctly.

New Features:
- Detect and preserve animation metadata on sent stickers by setting StickerMessage.IsAnimated based on the WebP container flags.

Bug Fixes:
- Allow animated WebP stickers received from URLs to be sent without failing on decoding or losing animation.
- Avoid unnecessary quality loss by no longer re-encoding already-WebP stickers at a fixed quality setting.

Enhancements:
- Cap remote sticker downloads by size to avoid unbounded memory usage and reject oversized payloads.
- Validate WebP RIFF container size before passthrough to avoid forwarding truncated or corrupted sticker files.