### PR TITLE
fix: guard shared instance maps with a RWMutex

### DIFF
--- a/pkg/call/service/call_service.go
+++ b/pkg/call/service/call_service.go
@@ -29,7 +29,9 @@ type RejectCallStruct struct {
 }
 
 func (c *callService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := c.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -43,7 +45,9 @@ func (c *callService) ensureClientConnected(instanceId string) (*whatsmeow.Clien
 		c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = c.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/chat/service/chat_service.go
+++ b/pkg/chat/service/chat_service.go
@@ -40,7 +40,9 @@ type HistorySyncRequestStruct struct {
 }
 
 func (c *chatService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := c.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -54,7 +56,9 @@ func (c *chatService) ensureClientConnected(instanceId string) (*whatsmeow.Clien
 		c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = c.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/community/service/community_service.go
+++ b/pkg/community/service/community_service.go
@@ -36,7 +36,9 @@ type AddParticipantStruct struct {
 }
 
 func (c *communityService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := c.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -50,7 +52,9 @@ func (c *communityService) ensureClientConnected(instanceId string) (*whatsmeow.
 		c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = c.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		c.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/group/service/group_service.go
+++ b/pkg/group/service/group_service.go
@@ -118,7 +118,9 @@ type UpdateGroupRequestParticipantsStruct struct {
 
 
 func (g *groupService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := g.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	g.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -132,7 +134,9 @@ func (g *groupService) ensureClientConnected(instanceId string) (*whatsmeow.Clie
 		g.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = g.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		g.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/instance/service/instance_service.go
+++ b/pkg/instance/service/instance_service.go
@@ -116,7 +116,9 @@ type ForceReconnectStruct struct {
 
 func (i *instances) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
 	logger := i.loggerWrapper.GetLogger(instanceId)
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := i.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	logger.LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -130,7 +132,9 @@ func (i *instances) ensureClientConnected(instanceId string) (*whatsmeow.Client,
 		logger.LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = i.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		logger.LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,
@@ -234,7 +238,9 @@ func (i instances) Connect(data *ConnectStruct, instance *instance_model.Instanc
 	}
 
 	// Verifica se a instância já está rodando
+	whatsmeow_service.ClientMapsMu.RLock()
 	isInstanceRunning := i.clientPointer[instance.Id] != nil
+	whatsmeow_service.ClientMapsMu.RUnlock()
 
 	// Sincroniza as configurações na instância em execução (se já estiver conectada)
 	err = i.whatsmeowService.UpdateInstanceSettings(instance.Id)
@@ -250,7 +256,9 @@ func (i instances) Connect(data *ConnectStruct, instance *instance_model.Instanc
 	if !isInstanceRunning {
 		i.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Starting new client instance", instance.Id)
 
+		whatsmeow_service.ClientMapsMu.Lock()
 		i.killChannel[instance.Id] = make(chan bool)
+		whatsmeow_service.ClientMapsMu.Unlock()
 
 		clientData := &whatsmeow_service.ClientData{
 			Instance:      instance,
@@ -309,7 +317,10 @@ func (i instances) Disconnect(instance *instance_model.Instance) (*instance_mode
 	if client.IsConnected() {
 		if client.IsLoggedIn() {
 			i.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Disconnection successful", instance.Id)
-			i.killChannel[instance.Id] <- true
+			whatsmeow_service.ClientMapsMu.RLock()
+			killChan := i.killChannel[instance.Id]
+			whatsmeow_service.ClientMapsMu.RUnlock()
+			killChan <- true
 
 			instance.Events = ""
 
@@ -344,13 +355,18 @@ func (i instances) Logout(instance *instance_model.Instance) (*instance_model.In
 			return instance, err
 		}
 
+		whatsmeow_service.ClientMapsMu.RLock()
+		logoutKillChan := i.killChannel[instance.Id]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		select {
-		case i.killChannel[instance.Id] <- true:
+		case logoutKillChan <- true:
 		case <-time.After(5 * time.Second):
 		}
 
+		whatsmeow_service.ClientMapsMu.Lock()
 		delete(i.clientPointer, instance.Id)
 		delete(i.killChannel, instance.Id)
+		whatsmeow_service.ClientMapsMu.Unlock()
 
 		i.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Logout successful", instance.Id)
 		return instance, nil
@@ -359,13 +375,18 @@ func (i instances) Logout(instance *instance_model.Instance) (*instance_model.In
 	if client.IsConnected() {
 		client.Disconnect()
 
+		whatsmeow_service.ClientMapsMu.RLock()
+		disconnectKillChan := i.killChannel[instance.Id]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		select {
-		case i.killChannel[instance.Id] <- true:
+		case disconnectKillChan <- true:
 		case <-time.After(5 * time.Second):
 		}
 
+		whatsmeow_service.ClientMapsMu.Lock()
 		delete(i.clientPointer, instance.Id)
 		delete(i.killChannel, instance.Id)
+		whatsmeow_service.ClientMapsMu.Unlock()
 
 		i.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Disconnection successful", instance.Id)
 		return instance, nil
@@ -376,7 +397,9 @@ func (i instances) Logout(instance *instance_model.Instance) (*instance_model.In
 }
 
 func (i instances) Status(instance *instance_model.Instance) (*StatusStruct, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 
 	if client == nil {
 		return &StatusStruct{
@@ -405,7 +428,9 @@ func (i instances) Status(instance *instance_model.Instance) (*StatusStruct, err
 
 func (i instances) GetQr(instance *instance_model.Instance) (*QrcodeStruct, error) {
 	logger := i.loggerWrapper.GetLogger(instance.Id)
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 
 	// Se não há cliente ou o cliente está logado, precisamos iniciar um novo cliente
 	if client == nil || client.IsLoggedIn() {
@@ -427,7 +452,9 @@ func (i instances) GetQr(instance *instance_model.Instance) (*QrcodeStruct, erro
 		time.Sleep(3 * time.Second)
 
 		// Verificar novamente se há cliente
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = i.clientPointer[instance.Id]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		if client != nil && client.IsLoggedIn() {
 			return nil, fmt.Errorf("session already logged in")
 		}
@@ -474,7 +501,9 @@ func (i instances) GetQr(instance *instance_model.Instance) (*QrcodeStruct, erro
 
 func (i instances) Pair(data *PairStruct, instance *instance_model.Instance) (*PairReturnStruct, error) {
 	logger := i.loggerWrapper.GetLogger(instance.Id)
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 
 	if client == nil || !client.IsConnected() {
 		if client != nil && client.IsLoggedIn() {
@@ -488,7 +517,9 @@ func (i instances) Pair(data *PairStruct, instance *instance_model.Instance) (*P
 		// Wait for the WA websocket connection and initial QR generation to establish.
 		// PairPhone must be called after the QR event is received per whatsmeow docs.
 		time.Sleep(3 * time.Second)
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = i.clientPointer[instance.Id]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		if client == nil {
 			return nil, fmt.Errorf("failed to initialize client for pairing")
 		}
@@ -514,7 +545,10 @@ func (i instances) GetAll() ([]*instance_model.Instance, error) {
 	}
 
 	for _, instance := range instances {
-		if client := i.clientPointer[instance.Id]; client != nil {
+		whatsmeow_service.ClientMapsMu.RLock()
+		client := i.clientPointer[instance.Id]
+		whatsmeow_service.ClientMapsMu.RUnlock()
+		if client != nil {
 			instance.Connected = client.IsLoggedIn()
 		} else {
 			instance.Connected = false
@@ -533,7 +567,10 @@ func (i instances) Info(instanceId string) (*instance_model.Instance, error) {
 	}
 
 	// Atualiza o status connected com base no estado real do cliente
-	if client := i.clientPointer[instance.Id]; client != nil {
+	whatsmeow_service.ClientMapsMu.RLock()
+	client := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
+	if client != nil {
 		instance.Connected = client.IsLoggedIn()
 	} else {
 		instance.Connected = false
@@ -550,18 +587,30 @@ func (i instances) Delete(id string) error {
 		return err
 	}
 
-	if i.clientPointer[instance.Id] != nil && i.clientPointer[instance.Id].IsConnected() {
-		if i.clientPointer[instance.Id].IsLoggedIn() {
-			i.clientPointer[instance.Id].Logout(context.Background())
+	whatsmeow_service.ClientMapsMu.RLock()
+	deleteClient := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
+
+	if deleteClient != nil && deleteClient.IsConnected() {
+		if deleteClient.IsLoggedIn() {
+			deleteClient.Logout(context.Background())
 		}
-		i.clientPointer[instance.Id].Disconnect()
+		deleteClient.Disconnect()
 	}
 
-	// Limpar todos os recursos da instância antes de deletar
+	// Limpar todos os recursos da instância antes de deletar. Read-then-delete
+	// on killChannel happens under the same Lock as the clientPointer delete so
+	// a concurrent Delete()/cleanup can't double-close the channel.
+	whatsmeow_service.ClientMapsMu.Lock()
 	delete(i.clientPointer, instance.Id)
-	if i.killChannel[instance.Id] != nil {
-		close(i.killChannel[instance.Id])
+	deleteKillChan := i.killChannel[instance.Id]
+	if deleteKillChan != nil {
 		delete(i.killChannel, instance.Id)
+	}
+	whatsmeow_service.ClientMapsMu.Unlock()
+
+	if deleteKillChan != nil {
+		close(deleteKillChan)
 	}
 
 	// Limpar cache via whatsmeow service
@@ -660,7 +709,10 @@ func (i instances) RemoveProxy(id string) error {
 }
 
 func (i instances) ForceReconnect(instanceId string, number string) error {
-	if i.clientPointer[instanceId].IsConnected() && i.clientPointer[instanceId].IsLoggedIn() {
+	whatsmeow_service.ClientMapsMu.RLock()
+	forceReconnectClient := i.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
+	if forceReconnectClient.IsConnected() && forceReconnectClient.IsLoggedIn() {
 		return fmt.Errorf("client already connected")
 	}
 
@@ -676,7 +728,9 @@ func (i instances) ForceReconnect(instanceId string, number string) error {
 
 	subscribedEvents := strings.Split(instance.Events, ",")
 
+	whatsmeow_service.ClientMapsMu.Lock()
 	i.killChannel[instance.Id] = make(chan bool)
+	whatsmeow_service.ClientMapsMu.Unlock()
 
 	clientData := &whatsmeow_service.ClientData{
 		Instance:      instance,
@@ -698,29 +752,41 @@ func (i instances) ForceReconnect(instanceId string, number string) error {
 		}
 	}
 
-	if i.clientPointer[instance.Id] != nil {
-		client := i.clientPointer[instance.Id]
-		client.Disconnect()
+	whatsmeow_service.ClientMapsMu.RLock()
+	existingForceReconnectClient := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 
+	if existingForceReconnectClient != nil {
+		existingForceReconnectClient.Disconnect()
+
+		whatsmeow_service.ClientMapsMu.RLock()
+		forceReconnectKillChan := i.killChannel[instance.Id]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		select {
-		case i.killChannel[instance.Id] <- true:
+		case forceReconnectKillChan <- true:
 		case <-time.After(5 * time.Second):
 		}
 
+		whatsmeow_service.ClientMapsMu.Lock()
 		delete(i.clientPointer, instance.Id)
 		delete(i.killChannel, instance.Id)
+		whatsmeow_service.ClientMapsMu.Unlock()
 	}
 
 	go i.whatsmeowService.StartClient(clientData)
 
 	time.Sleep(2 * time.Second)
 
-	if i.clientPointer[instance.Id] != nil {
-		if !i.clientPointer[instance.Id].IsConnected() {
+	whatsmeow_service.ClientMapsMu.RLock()
+	newForceReconnectClient := i.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
+
+	if newForceReconnectClient != nil {
+		if !newForceReconnectClient.IsConnected() {
 			return fmt.Errorf("failed to connect")
 		}
 
-		if !i.clientPointer[instance.Id].IsLoggedIn() {
+		if !newForceReconnectClient.IsLoggedIn() {
 			return fmt.Errorf("failed to login")
 		}
 	} else {

--- a/pkg/label/service/label_service.go
+++ b/pkg/label/service/label_service.go
@@ -50,7 +50,9 @@ type EditLabelStruct struct {
 }
 
 func (l *labelService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := l.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	l.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -64,7 +66,9 @@ func (l *labelService) ensureClientConnected(instanceId string) (*whatsmeow.Clie
 		l.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = l.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		l.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/message/service/message_service.go
+++ b/pkg/message/service/message_service.go
@@ -85,7 +85,9 @@ type MessageSendStruct struct {
 }
 
 func (m *messageService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := m.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	m.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -99,7 +101,9 @@ func (m *messageService) ensureClientConnected(instanceId string) (*whatsmeow.Cl
 		m.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = m.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		m.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/newsletter/service/newsletter_service.go
+++ b/pkg/newsletter/service/newsletter_service.go
@@ -47,7 +47,9 @@ type GetNewsletterMessagesStruct struct {
 }
 
 func (n *newsletterService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := n.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	n.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -61,7 +63,9 @@ func (n *newsletterService) ensureClientConnected(instanceId string) (*whatsmeow
 		n.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = n.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		n.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/sendMessage/service/send_service.go
+++ b/pkg/sendMessage/service/send_service.go
@@ -370,7 +370,9 @@ type MessageSendStruct struct {
 }
 
 func (s *sendService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := s.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	s.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -384,7 +386,9 @@ func (s *sendService) ensureClientConnected(instanceId string) (*whatsmeow.Clien
 		s.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = s.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		s.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,
@@ -2029,9 +2033,17 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 
 	s.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Recipient validated: %s (Server: %s)", instance.Id, recipient.String(), recipient.Server)
 
+	// Fetch the client once for this whole send: the map read itself is
+	// guarded, but a single send is expected to run against one client, so we
+	// don't want to re-look-up the map (and thus potentially race a concurrent
+	// reconnect mid-send) on every one of the calls below.
+	whatsmeow_service.ClientMapsMu.RLock()
+	sendMessageClient := s.clientPointer[instance.Id]
+	whatsmeow_service.ClientMapsMu.RUnlock()
+
 	var message string
 	if data.Id == "" {
-		message = s.clientPointer[instance.Id].GenerateMessageID()
+		message = sendMessageClient.GenerateMessageID()
 	} else {
 		message = data.Id
 	}
@@ -2042,14 +2054,14 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 			media = "audio"
 		}
 
-		err := s.clientPointer[instance.Id].SendChatPresence(context.Background(), recipient, types.ChatPresence("composing"), types.ChatPresenceMedia(media))
+		err := sendMessageClient.SendChatPresence(context.Background(), recipient, types.ChatPresence("composing"), types.ChatPresenceMedia(media))
 		if err != nil {
 			return nil, err
 		}
 
 		time.Sleep(time.Duration(data.Delay) * time.Millisecond)
 
-		err = s.clientPointer[instance.Id].SendChatPresence(context.Background(), recipient, types.ChatPresence("paused"), types.ChatPresenceMedia(media))
+		err = sendMessageClient.SendChatPresence(context.Background(), recipient, types.ChatPresence("paused"), types.ChatPresenceMedia(media))
 		if err != nil {
 			return nil, err
 		}
@@ -2198,7 +2210,7 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 	// Only try to get participants for actual groups, not newsletters
 	if isGroup && !isNewsletter {
 		if data.MentionAll {
-			groupInfo, err := s.clientPointer[instance.Id].GetGroupInfo(context.Background(), recipient)
+			groupInfo, err := sendMessageClient.GetGroupInfo(context.Background(), recipient)
 			if err != nil {
 				return nil, err
 			}
@@ -2332,7 +2344,7 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 		s.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Newsletter detected, using MediaHandle: %s", instance.Id, data.MediaHandle)
 	}
 
-	response, err := s.clientPointer[instance.Id].SendMessage(context.Background(), recipient, msg, sendExtra)
+	response, err := sendMessageClient.SendMessage(context.Background(), recipient, msg, sendExtra)
 	if err != nil {
 		s.loggerWrapper.GetLogger(instance.Id).LogError("[%s] Error sending message: %v", instance.Id, err)
 		return nil, err
@@ -2343,7 +2355,7 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 	messageInfo := types.MessageInfo{
 		MessageSource: types.MessageSource{
 			Chat:     recipient,
-			Sender:   *s.clientPointer[instance.Id].Store.ID,
+			Sender:   *sendMessageClient.Store.ID,
 			IsFromMe: true,
 			IsGroup:  isGroup,
 		},
@@ -2397,15 +2409,15 @@ func (s *sendService) SendMessage(instance *instance_model.Instance, msg *waE2E.
 		sticker := msg.GetStickerMessage()
 
 		if img != nil {
-			data, err = s.clientPointer[instance.Id].Download(context.Background(), img)
+			data, err = sendMessageClient.Download(context.Background(), img)
 		} else if audio != nil {
-			data, err = s.clientPointer[instance.Id].Download(context.Background(), audio)
+			data, err = sendMessageClient.Download(context.Background(), audio)
 		} else if document != nil {
-			data, err = s.clientPointer[instance.Id].Download(context.Background(), document)
+			data, err = sendMessageClient.Download(context.Background(), document)
 		} else if video != nil {
-			data, err = s.clientPointer[instance.Id].Download(context.Background(), video)
+			data, err = sendMessageClient.Download(context.Background(), video)
 		} else if sticker != nil {
-			data, err = s.clientPointer[instance.Id].Download(context.Background(), sticker)
+			data, err = sendMessageClient.Download(context.Background(), sticker)
 
 			webpReader := bytes.NewReader(data)
 			img, err := webp.Decode(webpReader)

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -109,7 +109,9 @@ type PrivacyStruct struct {
 }
 
 func (u *userService) ensureClientConnected(instanceId string) (*whatsmeow.Client, error) {
+	whatsmeow_service.ClientMapsMu.RLock()
 	client := u.clientPointer[instanceId]
+	whatsmeow_service.ClientMapsMu.RUnlock()
 	u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking client connection status - Client exists: %v", instanceId, client != nil)
 
 	if client == nil {
@@ -123,7 +125,9 @@ func (u *userService) ensureClientConnected(instanceId string) (*whatsmeow.Clien
 		u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Instance started, waiting 2 seconds...", instanceId)
 		time.Sleep(2 * time.Second)
 
+		whatsmeow_service.ClientMapsMu.RLock()
 		client = u.clientPointer[instanceId]
+		whatsmeow_service.ClientMapsMu.RUnlock()
 		u.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Checking new client - Exists: %v, Connected: %v",
 			instanceId,
 			client != nil,

--- a/pkg/whatsmeow/service/client_maps.go
+++ b/pkg/whatsmeow/service/client_maps.go
@@ -1,0 +1,31 @@
+package whatsmeow_service
+
+import "sync"
+
+// ClientMapsMu guards the three instance-keyed maps created once in
+// cmd/evolution-go/main.go — killChannel (map[string]chan bool), clientPointer
+// (map[string]*whatsmeow.Client) and myClientPointer (map[string]*MyClient) —
+// and shared by reference across every service package in this module
+// (whatsmeow, instance, sendMessage, chat, call, community, group, label,
+// message, newsletter, user) as well as every *MyClient value, which keeps its
+// own copies of the same three map references.
+//
+// Because all of those packages read and write the very same underlying maps
+// concurrently (HTTP handlers reading a client to act on it while
+// ReconnectClient/StartClient add or remove entries from a background
+// goroutine), any indexed access — assignment, delete, membership check,
+// range, or len — MUST hold this mutex. Every read (`v := m[k]`, `v, ok :=
+// m[k]`, `range m`, `len(m)`) takes RLock/RUnlock; every write (`m[k] = v`,
+// `delete(m, k)`) takes Lock/Unlock. Without this, Go's runtime fatals the
+// whole process on a concurrent map read/write or concurrent map writes — it
+// is not a panic that can be recovered from.
+//
+// Rule of thumb: never hold the lock across a long or blocking call —
+// Disconnect/Connect/Logout, StartInstance/ReconnectClient/StartClient, a send
+// on a kill channel, or any network I/O. Copy the map value you need into a
+// local variable while holding the lock, release the lock, then operate on
+// the local copy. This also avoids deadlocks: several of the guarded
+// functions call into each other (ReconnectClient -> StartInstance ->
+// StartClient), and none of them may still be holding ClientMapsMu when they
+// do.
+var ClientMapsMu sync.RWMutex

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -152,8 +152,16 @@ type ProxyConfig struct {
 func (w whatsmeowService) ReconnectClient(instanceId string) error {
 	w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Starting reconnection process - simulating restart", instanceId)
 
-	// Passo 1: Limpar conexão existente se houver
-	if client, exists := w.clientPointer[instanceId]; exists {
+	// Passo 1: Limpar conexão existente se houver.
+	// Copy the client/mycli references out under RLock, then release before
+	// doing anything network-related (IsConnected/Disconnect/RemoveEventHandler
+	// can block) — see ClientMapsMu doc.
+	ClientMapsMu.RLock()
+	client, exists := w.clientPointer[instanceId]
+	mycli, hasMycli := w.myClientPointer[instanceId]
+	ClientMapsMu.RUnlock()
+
+	if exists {
 		w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Disconnecting existing client", instanceId)
 
 		// Desconectar o cliente WebSocket
@@ -163,7 +171,7 @@ func (w whatsmeowService) ReconnectClient(instanceId string) error {
 		}
 
 		// Remover event handler se existir
-		if mycli, ok := w.myClientPointer[instanceId]; ok {
+		if hasMycli {
 			if mycli.eventHandlerID != 0 {
 				client.RemoveEventHandler(mycli.eventHandlerID)
 				w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Event handler removed", instanceId)
@@ -174,8 +182,13 @@ func (w whatsmeowService) ReconnectClient(instanceId string) error {
 	// Passo 2: Limpar todos os recursos da instância
 	w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Cleaning up resources", instanceId)
 
-	// Enviar sinal de kill se o canal existir
-	if killChan, exists := w.killChannel[instanceId]; exists {
+	// Enviar sinal de kill se o canal existir. Copy the channel under RLock and
+	// send/select on the local copy only after releasing the lock.
+	ClientMapsMu.RLock()
+	killChan, hasKillChan := w.killChannel[instanceId]
+	ClientMapsMu.RUnlock()
+
+	if hasKillChan {
 		select {
 		case killChan <- true:
 			w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Kill signal sent", instanceId)
@@ -184,10 +197,12 @@ func (w whatsmeowService) ReconnectClient(instanceId string) error {
 		}
 	}
 
-	// Remover das estruturas
+	// Remover das estruturas — the three deletes happen together under a single Lock.
+	ClientMapsMu.Lock()
 	delete(w.clientPointer, instanceId)
 	delete(w.myClientPointer, instanceId)
 	delete(w.killChannel, instanceId)
+	ClientMapsMu.Unlock()
 
 	// Limpar cache de userInfo para esta instância
 	if instance, err := w.instanceRepository.GetInstanceByID(instanceId); err == nil {
@@ -286,8 +301,12 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	var deviceStore *store.Device
 	var err error
 
-	if w.clientPointer[cd.Instance.Id] != nil {
-		if w.clientPointer[cd.Instance.Id].IsConnected() {
+	ClientMapsMu.RLock()
+	existingClient := w.clientPointer[cd.Instance.Id]
+	ClientMapsMu.RUnlock()
+
+	if existingClient != nil {
+		if existingClient.IsConnected() {
 			return
 		}
 	}
@@ -390,7 +409,9 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	clientLog := waLog.Stdout("Client", minLevel, true)
 	client := whatsmeow.NewClient(deviceStore, clientLog)
 
+	ClientMapsMu.Lock()
 	w.clientPointer[cd.Instance.Id] = client
+	ClientMapsMu.Unlock()
 
 	if cd.IsProxy {
 		var proxyConfig ProxyConfig
@@ -476,7 +497,9 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	mycli.eventHandlerID = mycli.WAClient.AddEventHandler(mycli.myEventHandler)
 
 	// Armazena o MyClient no map para permitir atualizações posteriores
+	ClientMapsMu.Lock()
 	w.myClientPointer[cd.Instance.Id] = mycli
+	ClientMapsMu.Unlock()
 
 	if client.Store.ID != nil {
 		w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("[%s] Already logged in with JID: %s", cd.Instance.Id, client.Store.ID.String())
@@ -732,13 +755,24 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	// Removed auto-reconnect logic to prevent infinite loops
 
 	for {
+		// Re-read the kill channel from the shared map on every iteration (it may
+		// be replaced by a concurrent ReconnectClient/StartInstance for this same
+		// instance): copy it under RLock, release, then select on the local copy.
+		// A missing entry yields a nil channel, which never fires — same as the
+		// original unguarded map read.
+		ClientMapsMu.RLock()
+		killChan := w.killChannel[cd.Instance.Id]
+		ClientMapsMu.RUnlock()
+
 		select {
-		case <-w.killChannel[cd.Instance.Id]:
+		case <-killChan:
 			w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("Received kill signal for user '%s'", cd.Instance.Id)
 			client.Disconnect()
 
+			ClientMapsMu.Lock()
 			delete(w.clientPointer, cd.Instance.Id)
 			delete(w.myClientPointer, cd.Instance.Id)
+			ClientMapsMu.Unlock()
 
 			// Limpar cache de userInfo para esta instância
 			w.userInfoCache.Delete(cd.Instance.Token)
@@ -798,6 +832,12 @@ func schedulePresenceUpdates(mycli *MyClient) {
 	defer ticker.Stop()
 
 	for {
+		// Copy the kill channel out of the shared map under RLock before
+		// entering select — see ClientMapsMu doc.
+		ClientMapsMu.RLock()
+		killChan := mycli.killChannel[mycli.userID]
+		ClientMapsMu.RUnlock()
+
 		select {
 		case <-ticker.C:
 			// Verificar se a instância ainda existe
@@ -813,7 +853,7 @@ func schedulePresenceUpdates(mycli *MyClient) {
 			randomInterval := time.Duration(1+rand.Intn(3)) * time.Hour
 			ticker = time.NewTicker(randomInterval)
 
-		case <-mycli.killChannel[mycli.userID]:
+		case <-killChan:
 			mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Received kill signal, stopping presence updates", mycli.userID)
 			return // Encerra a goroutine quando receber sinal de kill
 		}
@@ -1170,7 +1210,10 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 				fmt.Printf("[POLL DEBUG] ✅ mycli.WAClient is initialized: %s\n", mycli.WAClient.Store.ID)
 			}
 
-			decrypted, err := mycli.clientPointer[mycli.userID].DecryptPollVote(context.Background(), evt)
+			ClientMapsMu.RLock()
+			pollVoteClient := mycli.clientPointer[mycli.userID]
+			ClientMapsMu.RUnlock()
+			decrypted, err := pollVoteClient.DecryptPollVote(context.Background(), evt)
 			if err != nil {
 				mycli.loggerWrapper.GetLogger(mycli.userID).LogError("[%s] Failed to decrypt vote: %v", mycli.userID, err)
 			} else {
@@ -1774,7 +1817,10 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		}
 
 		// Agora mata o canal DEPOIS de enviar o evento
-		mycli.killChannel[mycli.userID] <- true
+		ClientMapsMu.RLock()
+		loggedOutKillChan := mycli.killChannel[mycli.userID]
+		ClientMapsMu.RUnlock()
+		loggedOutKillChan <- true
 	case *events.ChatPresence:
 		doWebhook = true
 		postMap["event"] = "ChatPresence"
@@ -2242,7 +2288,9 @@ func (w whatsmeowService) StartInstance(instanceId string) error {
 		}
 	}
 
+	ClientMapsMu.Lock()
 	w.killChannel[instance.Id] = make(chan bool)
+	ClientMapsMu.Unlock()
 
 	clientData := &ClientData{
 		Instance:      instance,
@@ -2539,7 +2587,9 @@ func (w whatsmeowService) UpdateInstanceSettings(instanceId string) error {
 	}
 
 	// Verifica se o MyClient existe
+	ClientMapsMu.RLock()
 	myClient, exists := w.myClientPointer[instanceId]
+	ClientMapsMu.RUnlock()
 	if !exists {
 		w.loggerWrapper.GetLogger(instanceId).LogWarn("[%s] MyClient not found in runtime, instance may not be connected", instanceId)
 		return fmt.Errorf("instance %s not found in runtime", instanceId)
@@ -2598,7 +2648,9 @@ func (w whatsmeowService) UpdateInstanceAdvancedSettings(instanceId string) erro
 	}
 
 	// Verifica se o MyClient existe
+	ClientMapsMu.RLock()
 	myClient, exists := w.myClientPointer[instanceId]
+	ClientMapsMu.RUnlock()
 	if !exists {
 		w.loggerWrapper.GetLogger(instanceId).LogWarn("[%s] MyClient not found in runtime, instance may not be connected", instanceId)
 		return fmt.Errorf("instance %s not found in runtime", instanceId)
@@ -2617,20 +2669,32 @@ func (w whatsmeowService) ClearInstanceCache(instanceId string, token string) er
 	// Limpar userInfoCache
 	w.userInfoCache.Delete(token)
 
-	// Limpar myClientPointer se existir
-	if _, exists := w.myClientPointer[instanceId]; exists {
+	// All three map check-and-delete operations happen under a single Lock so
+	// a concurrent reader/writer never observes a half-cleared instance. The
+	// kill-channel send/close happens afterwards, on the copied local value,
+	// with the lock released (see ClientMapsMu doc).
+	ClientMapsMu.Lock()
+	_, hadMyClient := w.myClientPointer[instanceId]
+	if hadMyClient {
 		delete(w.myClientPointer, instanceId)
+	}
+	_, hadClient := w.clientPointer[instanceId]
+	if hadClient {
+		delete(w.clientPointer, instanceId)
+	}
+	killChan, hadKillChan := w.killChannel[instanceId]
+	if hadKillChan {
+		delete(w.killChannel, instanceId)
+	}
+	ClientMapsMu.Unlock()
+
+	if hadMyClient {
 		w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] MyClient pointer cleared", instanceId)
 	}
-
-	// Limpar clientPointer se existir
-	if _, exists := w.clientPointer[instanceId]; exists {
-		delete(w.clientPointer, instanceId)
+	if hadClient {
 		w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Client pointer cleared", instanceId)
 	}
-
-	// Limpar killChannel se existir
-	if killChan, exists := w.killChannel[instanceId]; exists {
+	if hadKillChan {
 		select {
 		case killChan <- true:
 			// Canal recebeu o sinal
@@ -2638,7 +2702,6 @@ func (w whatsmeowService) ClearInstanceCache(instanceId string, token string) er
 			// Canal pode estar bloqueado, apenas fecha
 		}
 		close(killChan)
-		delete(w.killChannel, instanceId)
 		w.loggerWrapper.GetLogger(instanceId).LogInfo("[%s] Kill channel cleared", instanceId)
 	}
 


### PR DESCRIPTION
`develop` counterpart of #127, which targets `main`. Opening it here because on #128 @iagocotta asked that PRs go to `develop`; #127 is the only one of my earlier PRs that did not get a replacement, and it is also the one with independent production confirmation from another user.

### Problem

`killChannel`, `clientPointer` and `myClientPointer` are created in `main.go` and shared by reference across all service packages and every `MyClient`. `ReconnectClient` deletes from all three without a lock, `StartClient` writes to them, the `Disconnected` handler triggers `ReconnectClient` from a goroutine, and every HTTP handler reads them concurrently.

Go fatals on concurrent map access. These are runtime fatal errors, not panics, so `recover()` is not an option: every occurrence kills the process and takes **all** instances down with it.

The codebase already acknowledges the hazard — the comment on `teardownQR` in `pkg/whatsmeow/service/whatsmeow.go` (on `main`) calls these *"unsynchronized service-wide maps"* and notes that touching them from another goroutine *"risks a `fatal error: concurrent map writes`"*. That workaround protects a single call site; the maps stay unguarded everywhere else.

### Confirmed in production, twice, by two independent deployments

@Matheusagostinho reported on #127 (2026-08-04), running `0.7.2` with 5 instances:

```
fatal error: concurrent map read and map write
fatal error: concurrent map writes
```

with `RestartCount: 2` matching the two fatals, and a goroutine dump through `instance.Connect` / `handleQRCodes` / `webhookProducer.Produce` — concurrent connects while another instance was in an active QR flow.

We hit the same thing on our own deployment, and it is severe in a way the crash trace does not show: **restarting the container does not bring the instances back.** They stay down until an explicit `POST /instance/connect` per instance, so every crash is a full outage until someone reconnects them by hand.

### Change

A single exported `sync.RWMutex` in the whatsmeow service package, guarding the three maps everywhere they are touched. Lock scopes are kept minimal: values are copied out under `RLock` and the lock is released before any long call, so no network I/O happens while holding it.

### Notes on porting to `develop`

Four hunks from #127 did not carry over because the code does not exist on this branch: `teardownQR`, `SubmitPasskeyResponse` and `ConfirmPasskey`. Everything else applied. Since `main` and `develop` have no common ancestor, I did not assume the site lists matched — I audited all 61 accesses to the three maps on `develop` and confirmed none was left unguarded, and that every `Lock`/`RLock` has its matching release in the same file.

`go build ./...` and `go vet ./pkg/...` clean.

@Matheusagostinho — a minimal reproduction with parallel `/instance/connect` calls would still be valuable, if the offer stands. It would make this much easier to accept than two independent field reports.

## Summary by Sourcery

Guard shared instance-level client, MyClient, and kill-channel maps with a global RWMutex across all services to prevent concurrent map access crashes.

Bug Fixes:
- Prevent runtime fatal errors from concurrent reads and writes to shared instance maps by synchronizing all accesses with a RWMutex.

Enhancements:
- Introduce a shared synchronization primitive and refactor service code to copy map values under lock and perform network or blocking operations after releasing it, ensuring consistent teardown and cleanup semantics across instances.