### PR TITLE
fix: connection pool leak in StartClient (sqlstore.New opens unbounded pool every reconnect)

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -316,21 +316,24 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	var container *sqlstore.Container
 
+	var dbLog waLog.Logger
 	if w.config.WaDebug != "" {
-		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
-		}
+		dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+	}
+
+	if w.config.PostgresAuthDB != "" {
+		// Reuse the shared, pool-limited connection (w.authDB, configured with
+		// SetMaxOpenConns/SetConnMaxIdleTime in initPostgresAuthDB) instead of
+		// opening a brand-new, unbounded Postgres connection pool on every call.
+		// sqlstore.New() calls sql.Open() internally, and the resulting
+		// container was never closed here — every reconnect (disconnect retry,
+		// session check, API ConnectInstance) leaked one idle connection that
+		// accumulated for days until the shared Postgres pool was exhausted.
+		container = sqlstore.NewWithDB(w.authDB, "postgres", dbLog)
+		err = container.Upgrade(context.Background()) // NewWithDB skips the auto-upgrade New() does
 	} else {
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)
-		}
+		dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+		container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Problem

`StartClient()` (called on every reconnect: disconnect retries, session
checks, `ConnectInstance` API calls) creates the whatsmeow session store
container via:

```go
container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
```

`sqlstore.New()` calls `sql.Open()` internally, opening a **brand-new,
unbounded** Postgres connection pool on every call — and the resulting
`container` is never closed anywhere in `StartClient()`. Each reconnect
leaks one idle connection that is never released.

On a shared Postgres instance, this accumulates over days until
`max_connections` is exhausted, and **every other service/database sharing
that Postgres** starts failing with:

```
FATAL: remaining connection slots are reserved for non-replication superuser connections (SQLSTATE 53300)
```

We hit this in production 4 times over ~10 days (self-hosted, shared
Postgres): 2026-07-31, 2026-08-04, 2026-08-06 (escalated to exhausting even
the superuser-reserved slots, requiring a full `docker restart` of the
shared Postgres — affecting unrelated projects on the same server), and
2026-08-08 (~43 idle `evogo_auth_user` connections, oldest ~1d19h,
106/100 connections at capture time).

## Root cause

`whatsmeowService` already opens `authDB` **once**, at startup, with a
correctly bounded pool (`initPostgresAuthDB` in `cmd/evolution-go/main.go`):

```go
db.SetMaxOpenConns(25)
db.SetMaxIdleConns(5)
db.SetConnMaxLifetime(5 * time.Minute)
db.SetConnMaxIdleTime(1 * time.Minute)
```

...and injects it into `whatsmeowService.authDB` via `NewWhatsmeowService`.
But `StartClient()` never uses it for the whatsmeow session store — it
opens a fresh, unbounded pool from the DSN string every time instead.

## Fix

Use `sqlstore.NewWithDB(w.authDB, "postgres", dbLog)` — which wraps an
*existing* `*sql.DB` instead of opening a new one — reusing the
already-pooled, already-limited connection. Since `NewWithDB` skips the
auto-upgrade that `New()` performs, `container.Upgrade(ctx)` is called
explicitly right after.

The sqlite fallback path (`PostgresAuthDB == ""`) is untouched — it isn't
the source of this leak (local file, not a shared server).

## Validation

I wasn't able to run `go build ./...` for this PR — my local Docker
daemon has a corrupted/read-only containerd filesystem unrelated to this
repo, and I don't have a local Go toolchain. The change is a 2-line
semantic substitution (confirmed against `go.mau.fi/whatsmeow`'s
`store/sqlstore/container.go` — `NewWithDB(db *sql.DB, dialect string, log waLog.Logger) *Container`
signature matches exactly what's used here), but please run a build/lint
pass before merging — I couldn't verify it locally this time.

## Related

Full incident history (4 occurrences, mitigation steps, `pg_stat_activity`
snapshots) documented downstream in a consumer project's backlog:
https://github.com/jefersonfborba/tabloides/blob/master/docs/backlog.md
(search "BL-028").

## Summary by Sourcery

Reuse the existing pooled Postgres connection for the Whatsmeow session store to prevent connection pool leaks on client reconnects.

Bug Fixes:
- Fix a Postgres connection leak caused by opening a new, unbounded connection pool on every StartClient reconnect without closing it.

Enhancements:
- Standardize session store initialization to use a shared Postgres DB handle when configured, while keeping the sqlite fallback behavior unchanged.