### PR TITLE
fix(whatsmeow): reuse pooled authDB connection in StartClient instead of leaking a new pool per call

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -319,14 +319,20 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 	if w.config.WaDebug != "" {
 		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
 		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
+			// Reaproveita o pool já existente e limitado (w.authDB) em vez de abrir
+			// um *sql.DB novo e sem limites a cada StartClient — sqlstore.New()
+			// vazava um pool inteiro por chamada (nunca fechado), esgotando o
+			// max_connections do Postgres em produção.
+			container = sqlstore.NewWithDB(w.authDB, "postgres", dbLog)
+			err = container.Upgrade(context.Background())
 		} else {
 			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
 			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
 		}
 	} else {
 		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
+			container = sqlstore.NewWithDB(w.authDB, "postgres", nil)
+			err = container.Upgrade(context.Background())
 		} else {
 			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
 			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -316,13 +316,15 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	var container *sqlstore.Container
 
+	if w.config.PostgresAuthDB != "" && w.authDB == nil {
+		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] PostgresAuthDB is set but authDB was never initialized", cd.Instance.Id)
+		return
+	}
+
 	if w.config.WaDebug != "" {
 		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
 		if w.config.PostgresAuthDB != "" {
-			// Reaproveita o pool já existente e limitado (w.authDB) em vez de abrir
-			// um *sql.DB novo e sem limites a cada StartClient — sqlstore.New()
-			// vazava um pool inteiro por chamada (nunca fechado), esgotando o
-			// max_connections do Postgres em produção.
+			// Reuse the shared, pooled authDB instead of opening a new unbounded pool per call.
 			container = sqlstore.NewWithDB(w.authDB, "postgres", dbLog)
 			err = container.Upgrade(context.Background())
 		} else {


### PR DESCRIPTION
## Problem

`StartClient` (`pkg/whatsmeow/service/whatsmeow.go`) opens a brand new `*sql.DB` connection pool on every call, via:

```go
container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
```

`sqlstore.New` internally does `sql.Open(dialect, address)` — a fresh, completely unbounded pool (no `SetMaxOpenConns`/`SetMaxIdleConns`/`SetConnMaxLifetime`), independent from the properly-configured GORM pool set up in `pkg/config/config.go`. The `container` variable is local to `StartClient` and is never closed (`container.Close()` is not called anywhere in the file), so every call leaks the entire underlying connection pool.

`StartClient` is called repeatedly during normal operation, not just once per process lifetime:
- on the `LoggedOut` event auto-restart (whatsmeow.go, "restart client")
- on `CONNECT_ON_STARTUP`
- when updating settings of an already-running instance
- on manual reconnect (`POST /instance/connect`) — note this path only calls `client.Disconnect()` on the old `whatsmeow.Client`, it never closes the old `sqlstore.Container`/pool before creating a new one

In production, with only a couple of WhatsApp instances reconnecting periodically (WhatsApp forces session logout for various reasons on its own, no user action required), this accumulated ~95 idle Postgres connections over about 2 days and exhausted `max_connections`, taking down the whole app with `remaining connection slots are reserved for roles with the SUPERUSER attribute` — including breaking evolution-go's own ability to open new connections, so instances got stuck in a reconnect-fail loop.

## Fix

`whatsmeowService` already holds `authDB *sql.DB` — the same GORM-backed, properly pool-limited connection injected via `NewWhatsmeowService`. `sqlstore` exposes `NewWithDB(db *sql.DB, dialect string, log)` exactly for reusing an existing connection instead of opening a new one. This PR switches the Postgres branches of `StartClient` to:

```go
container = sqlstore.NewWithDB(w.authDB, "postgres", dbLog)
err = container.Upgrade(context.Background())
```

`NewWithDB` doesn't run `Upgrade` automatically like `New` does, so the `Upgrade` call is made explicitly right after, preserving the original behavior (schema stays up to date) while reusing the bounded pool instead of leaking a new one per call.

The SQLite branches are untouched — `w.sqliteDB` wraps a different file (`dbdata/users.db` vs. the whatsmeow store's `dbdata/main.db`), so blindly reusing it there would point at the wrong database; fixing that path would need separate investigation and is out of scope for this fix.

## Testing

- `CGO_ENABLED=1 go build ./cmd/evolution-go` — builds cleanly.
- Deployed the patched binary to a production instance (2 workspaces, Postgres-backed `POSTGRES_AUTH_DB`, `max_connections=100` shared with other apps on the same server). Before the fix, `pg_stat_activity` showed the `evolution` role accumulating idle connections on every instance reconnect/restart, with recurring `Failed to create container: failed to upgrade database: ... remaining connection slots are reserved for roles with the SUPERUSER attribute` in the logs. After deploying the fix and restarting, idle connections for the `evolution` role stayed at 1-2 across multiple reconnect cycles, with no recurrence of the pool-exhaustion error.

## Summary by Sourcery

Bug Fixes:
- Fix Postgres connection pool leaks caused by StartClient creating a new unbounded sql.DB on each invocation instead of reusing the shared authDB pool.