### PR TITLE
fix(whatsmeow): prevent panic when handling *events.Archive

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1694,11 +1694,16 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		doWebhook = true
 		postMap["event"] = "Archive"
 
-		dataMap := postMap["data"].(map[string]interface{})
-		dataMap["JID"] = evt.JID
-		dataMap["Timestamp"] = evt.Timestamp
-		dataMap["Action"] = evt.Action
-		dataMap["FromFullSync"] = evt.FromFullSync
+		// postMap["data"] still holds the raw *events.Archive here, so the
+		// direct map type assertion panicked on every Archive event (a fresh
+		// pairing history sync emits thousands). Build the map explicitly,
+		// like the other guarded cases do.
+		dataMap := map[string]interface{}{
+			"JID":          evt.JID,
+			"Timestamp":    evt.Timestamp,
+			"Action":       evt.Action,
+			"FromFullSync": evt.FromFullSync,
+		}
 		postMap["data"] = dataMap
 
 		mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Chat archived", mycli.userID)


### PR DESCRIPTION
## Problem

`myEventHandler` initializes `postMap["data"]` with the raw event (`interface{}`). The `*events.Archive` case then asserts it directly to `map[string]interface{}`:

```go
dataMap := postMap["data"].(map[string]interface{})
```

Since `postMap["data"]` still holds the `*events.Archive` struct at that point, this assertion **panics on every single Archive event**. whatsmeow recovers the panic, but the Archive webhook is never delivered, and a freshly paired device floods the logs during initial history sync — we measured **2,512 recovered panics in 40 minutes** on production (v0.7.2) right after pairing a device with many archived chats:

```
[Client ERROR] Event handler panicked while handling a *events.Archive: interface conversion: interface {} is *events.Archive, not map[string]interface {}
```

## Fix

Build the data map explicitly, the same way the other guarded cases (Connected, LoggedOut, etc.) already do after their JSON round-trip.

## Testing

Running in production since 2026-08-18 on a build of v0.7.2 with this patch: zero Archive panics (previously thousands during history sync), Archive webhooks delivered normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent Archive event handling from panicking and ensure Archive webhooks are delivered correctly.