### PR TITLE
fix(whatsmeow): reuse pooled authDB connection in StartClient (fixes #175)

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -294,21 +294,29 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	var container *sqlstore.Container
 
+	var dbLog waLog.Logger
 	if w.config.WaDebug != "" {
-		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
+		dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+	}
+
+	if w.config.PostgresAuthDB != "" && w.authDB != nil {
+		// Reuse the already-pooled, bounded authDB connection (SetMaxOpenConns/SetMaxIdleConns
+		// are configured once in config.CreateAuthDB) instead of opening a brand new *sql.DB via
+		// sqlstore.New on every StartClient call. StartClient runs on every reconnect, including
+		// the kill-channel restart path, so calling sqlstore.New here leaked one unbounded
+		// connection pool per call (see issue #175).
+		container = sqlstore.NewWithDB(w.authDB, "postgres", dbLog)
+		if err = container.Upgrade(context.Background()); err != nil {
+			w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to upgrade container: %v", cd.Instance.Id, err)
+			return
 		}
+	} else if w.config.PostgresAuthDB != "" {
+		// authDB should always be set when PostgresAuthDB is configured (see main.go), but fall
+		// back to the old per-call behavior rather than panicking on a nil *sql.DB.
+		container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
 	} else {
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)
-		}
+		dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+		container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Problem

`StartClient` calls `sqlstore.New(ctx, "postgres", config.PostgresAuthDB, ...)` on every invocation, opening a brand new `*sql.DB` connection pool each time. `container.Close()` is never called, so the old pool (and every connection it opened) is simply dropped.

`StartClient` is re-entered on:
- `ReconnectClient`, which calls `StartInstance` -> `StartClient` again
- the kill-channel branch of `StartClient`'s own select loop, which unconditionally restarts on any kill signal
- every QR pairing attempt that ends in a restart

Each path leaks one unbounded connection pool. Reproduced locally against a real Postgres instance: 15 consecutive `POST /instance/reconnect` calls grew `evogo_auth` connections from a baseline of 2 to 32, exceeding the app's own `SetMaxOpenConns(25)` cap, which confirms the leaked connections come from a pool outside the one the app manages. In production this exhausts `max_connections` under normal instance create/reconnect activity, surfacing as `pq: sorry, too many clients already` and QR pairing timeouts.

Closes #175.

## Fix

Reuse the already-pooled, bounded `authDB *sql.DB` (`whatsmeowService` already holds it as a field, configured once in `config.CreateAuthDB` with `SetMaxOpenConns`/`SetMaxIdleConns`/`SetConnMaxLifetime`/`SetConnMaxIdleTime`) via `sqlstore.NewWithDB(w.authDB, "postgres", dbLog)` instead of opening a new pool per call, then run `container.Upgrade(ctx)` explicitly since `NewWithDB` does not auto-upgrade like `sqlstore.New` does.

Falls back to the previous `sqlstore.New` behavior if `authDB` is unexpectedly `nil` (it should always be set when `PostgresAuthDB` is configured, see `main.go`), so this can't introduce a nil-pointer panic.

No changes to the SQLite fallback path.

## Verification

Tested against a real Postgres 192.168.x LAN instance with an actual WhatsApp session paired via QR:

| | Before fix | After fix |
|---|---|---|
| Baseline connections | 2 | 2 |
| After 15x `/instance/reconnect` | 32 (exceeds pool cap of 25) | 2 |
| Session state after cycling | `Connected: true`, `LoggedIn: true` | `Connected: true`, `LoggedIn: true` |

`go build ./...` passes on top of `develop` with the `whatsmeow-lib` submodule initialized.

## Notes

This is the same root cause already reported/attempted in #102, #117, #131, #168 and #174. This PR takes the smaller-diff approach from #168/#174 (reuse `w.authDB` via `NewWithDB` rather than introducing a new package-level singleton container), and additionally guards against a nil `authDB` per the review feedback left on #174.

## Summary by Sourcery

Prevent WhatsApp client restarts from leaking PostgreSQL connection pools by reusing the configured authentication database connection.

Bug Fixes:
- Reuse the existing bounded PostgreSQL authentication database pool across WhatsApp client restarts to prevent connection-pool leaks and database connection exhaustion.
- Preserve a safe fallback to per-call PostgreSQL initialization when the shared authentication database is unexpectedly unavailable.

Enhancements:
- Explicitly upgrade reused WhatsApp database containers while retaining the existing SQLite fallback path.