### PR TITLE
feat(user): add endpoint to resolve phone number from LID

### DIFF
--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -142,6 +142,7 @@ func (r *Routes) AssignRoutes(eng *gin.Engine) {
 			routes.POST("/profilePicture", r.userHandler.SetProfilePicture)
 			routes.POST("/profileName", r.userHandler.SetProfileName)
 			routes.POST("/profileStatus", r.userHandler.SetProfileStatus)
+			routes.POST("/lid", r.jidValidationMiddleware.ValidateJIDFields("lid", "groupJid"), r.userHandler.ResolveLid)
 		}
 	}
 	routes = eng.Group("/message")

--- a/pkg/user/handler/user_handler.go
+++ b/pkg/user/handler/user_handler.go
@@ -21,6 +21,7 @@ type UserHandler interface {
 	SetProfilePicture(ctx *gin.Context)
 	SetProfileName(ctx *gin.Context)
 	SetProfileStatus(ctx *gin.Context)
+	ResolveLid(ctx *gin.Context)
 }
 
 type userHandler struct {
@@ -540,6 +541,47 @@ func (u *userHandler) SetProfileStatus(ctx *gin.Context) {
 	responseData := gin.H{"status": data.Status}
 
 	ctx.JSON(http.StatusOK, gin.H{"message": "success", "data": responseData})
+}
+
+// Resolve the phone number behind a LID
+// @Summary Resolve the phone number behind a LID
+// @Description Resolve the phone number behind a LID
+// @Tags User
+// @Accept json
+// @Produce json
+// @Param message body user_service.ResolveLidStruct true "Lid data"
+// @Success 200 {object} gin.H "success"
+// @Failure 400 {object} gin.H "Error on validation"
+// @Failure 500 {object} gin.H "Internal server error"
+// @Router /user/lid [post]
+func (u *userHandler) ResolveLid(ctx *gin.Context) {
+	getInstance := ctx.MustGet("instance")
+
+	instance, ok := getInstance.(*instance_model.Instance)
+	if !ok {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": "instance not found"})
+		return
+	}
+
+	var data *user_service.ResolveLidStruct
+	err := ctx.ShouldBindBodyWithJSON(&data)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if data.Lid == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "lid is required"})
+		return
+	}
+
+	resp, err := u.userService.ResolveLid(data, instance)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "success", "data": resp})
 }
 
 func NewUserHandler(

--- a/pkg/user/service/user_service.go
+++ b/pkg/user/service/user_service.go
@@ -30,6 +30,7 @@ type UserService interface {
 	SetProfilePicture(data *SetProfilePictureStruct, instance *instance_model.Instance) (bool, error)
 	SetProfileName(data *SetProfileNameStruct, instance *instance_model.Instance) (bool, error)
 	SetProfileStatus(data *SetProfileStatusStruct, instance *instance_model.Instance) (bool, error)
+	ResolveLid(data *ResolveLidStruct, instance *instance_model.Instance) (*ResolveLidResult, error)
 }
 
 type userService struct {
@@ -96,6 +97,17 @@ type SetProfileNameStruct struct {
 
 type SetProfileStatusStruct struct {
 	Status string `json:"status"`
+}
+
+type ResolveLidStruct struct {
+	Lid      string `json:"lid"`
+	GroupJid string `json:"groupJid,omitempty"`
+}
+
+type ResolveLidResult struct {
+	Lid         string `json:"lid"`
+	PhoneNumber string `json:"phoneNumber"`
+	JID         string `json:"jid"`
 }
 
 type PrivacyStruct struct {
@@ -313,6 +325,62 @@ func (u *userService) mergeCheckUserResults(original, retry *CheckUserCollection
 	}
 
 	return merged
+}
+
+// ResolveLid resolves the phone number mapped to a LID (Linked Identity, "xxxx@lid").
+// This only reads whatsmeow's local LID store: the WhatsApp protocol has no
+// server query for LID->PN (only the inverse, PN->LID, is supported). The
+// mapping is only known locally after it has been received passively (e.g.
+// a message from that LID, or a group with LID-based participants). As a
+// best-effort fallback, when a groupJid is provided and the mapping is
+// missing, a fresh GetGroupInfo on that group can populate it, since group
+// participant lists include the phone number for LID participants.
+func (u *userService) ResolveLid(data *ResolveLidStruct, instance *instance_model.Instance) (*ResolveLidResult, error) {
+	client, err := u.ensureClientConnected(instance.Id)
+	if err != nil {
+		return nil, err
+	}
+
+	lidJID, ok := utils.ParseJID(data.Lid)
+	if !ok || lidJID.Server != types.HiddenUserServer {
+		return nil, errors.New("invalid lid")
+	}
+
+	if client.Store.LIDs == nil {
+		return nil, errors.New("lid store unavailable")
+	}
+
+	ctx := context.Background()
+
+	pn, err := client.Store.LIDs.GetPNForLID(ctx, lidJID)
+	if err != nil {
+		return nil, err
+	}
+
+	if pn.IsEmpty() && data.GroupJid != "" {
+		groupJID, ok := utils.ParseJID(data.GroupJid)
+		if !ok || groupJID.Server != types.GroupServer {
+			return nil, errors.New("invalid groupJid")
+		}
+
+		u.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] No cached phone number for lid %s, refreshing group %s as fallback", instance.Id, lidJID, groupJID)
+
+		if _, groupErr := client.GetGroupInfo(ctx, groupJID); groupErr != nil {
+			u.loggerWrapper.GetLogger(instance.Id).LogWarn("[%s] Failed to refresh group %s for lid fallback: %v", instance.Id, groupJID, groupErr)
+		} else if pn, err = client.Store.LIDs.GetPNForLID(ctx, lidJID); err != nil {
+			return nil, err
+		}
+	}
+
+	if pn.IsEmpty() {
+		return nil, errors.New("no phone number mapping found for this lid")
+	}
+
+	return &ResolveLidResult{
+		Lid:         lidJID.String(),
+		PhoneNumber: pn.User,
+		JID:         pn.String(),
+	}, nil
 }
 
 func (u *userService) GetAvatar(data *GetAvatarStruct, instance *instance_model.Instance) (*types.ProfilePictureInfo, error) {


### PR DESCRIPTION
## Summary
- Adds `POST /user/lid` to resolve a LID (`xxxx@lid`) back to its phone number, reading whatsmeow's local LID store (`client.Store.LIDs.GetPNForLID`).
- The WhatsApp protocol only supports server-side resolution in the PN -> LID direction; LID -> PN mappings are only known once received passively (message, group sync, etc). As a best-effort fallback, an optional `groupJid` in the request body triggers a fresh `GetGroupInfo` on that group (participant lists include phone numbers for LID participants), then retries the lookup before giving up.

## Request/response
```
POST /user/lid
{ "lid": "123456789012345@lid", "groupJid": "120363012345678901@g.us" }

200 { "message": "success", "data": { "lid": "...@lid", "phoneNumber": "...", "jid": "...@s.whatsapp.net" } }
```

## Test plan
- [x] `go build ./pkg/user/...` passes
- [ ] Manual test against a live instance with a known LID/group pair

## Summary by Sourcery

Expose phone-number resolution for WhatsApp LIDs through the user API.

New Features:
- Add a user endpoint that resolves a WhatsApp LID to its corresponding phone number and JID.
- Support an optional group lookup fallback when the LID mapping is not cached locally.