### PR TITLE
fix(group): use array-aware validation for participants

### DIFF
--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -181,7 +181,7 @@ func (r *Routes) AssignRoutes(eng *gin.Engine) {
 			routes.POST("/name", r.jidValidationMiddleware.ValidateNumberField(), r.groupHandler.SetGroupName)
 			routes.POST("/description", r.jidValidationMiddleware.ValidateNumberField(), r.groupHandler.SetGroupDescription)
 			routes.POST("/create", r.jidValidationMiddleware.ValidateMultipleNumbers("participants"), r.groupHandler.CreateGroup)
-			routes.POST("/participant", r.jidValidationMiddleware.ValidateJIDFields("number", "participants"), r.groupHandler.UpdateParticipant)
+			routes.POST("/participant", r.jidValidationMiddleware.ValidateMultipleNumbers("participants"), r.groupHandler.UpdateParticipant)
 			routes.GET("/myall", r.groupHandler.GetMyGroups) // TODO: not working
 			routes.POST("/join", r.groupHandler.JoinGroupLink)
 			routes.POST("/leave", r.jidValidationMiddleware.ValidateNumberField(), r.groupHandler.LeaveGroup)


### PR DESCRIPTION
## Description

Fixes the validation used by `POST /group/participant`.

The `participants` field is an array, but the route was using `ValidateJIDFields`, which handles individual string fields. Valid participant requests were therefore rejected before reaching `UpdateParticipant`.

This change uses the existing array-aware `ValidateMultipleNumbers("participants")` middleware, matching the behavior already used by `/group/create`.

## Related Issue

Closes #97

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* [x] No breaking changes introduced
* [ ] Manual testing completed
* [ ] Functionality verified in development environment

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [ ] I have tested my changes thoroughly
* [x] No dependent changes are required

## Additional Notes

Supersedes #100. This PR was created from the current upstream `develop` branch and contains one focused commit changing one file.
