### PR TITLE
fix: reuse a single sqlstore.Container instead of one per StartClient

### DIFF
--- a/.github/workflows/publish_ghcr_image.yml
+++ b/.github/workflows/publish_ghcr_image.yml
@@ -1,0 +1,83 @@
+# Publica a imagem deste fork no GHCR.
+#
+# Diferencas em relacao ao publish_docker_image.yml do upstream, que continua no
+# repo e deve ser desabilitado pela aba Actions (sem editar o arquivo, para nao
+# criar divergencia a rebasear a cada versao nova do fornecedor):
+#
+#   - Publica em ghcr.io/saphiracode, nao no Docker Hub do fornecedor.
+#   - Dispara em tag, nao em push para main. Publicar e ato deliberado, e a tag
+#     e o que os manifests do d360-backend referenciam.
+#   - Constroi apenas linux/arm64, em runner arm64 nativo. O no do k8s (Ampere,
+#     OCI) e o servidor de homolog sao ambos aarch64, e o Dockerfile usa
+#     CGO_ENABLED=1 — nao existe binario universal. Runner nativo evita emulacao
+#     QEMU, que com CGO e lenta e fragil.
+#   - Nao gera "latest". Tag imutavel e o que permite saber qual binario esta em
+#     producao, que era exatamente o que faltava no incidente DENT-248.
+
+name: Publish image to GHCR
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and push (linux/arm64)
+    # Runner arm64 nativo — gratuito em repositorio publico.
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Minusculas: o GHCR rejeita maiusculas no nome e a org e "SaphiraCode".
+          images: ghcr.io/saphiracode/evolution-go
+          # Tag v0.7.2-dent248.1 vira imagem 0.7.2-dent248.1.
+          tags: |
+            type=match,pattern=v(.*),group=1
+
+      - name: Stamp VERSION with the released tag
+        # O Dockerfile copia ./VERSION para /app/VERSION, e e la que a operacao
+        # confere qual build esta rodando. Sem isso o arquivo diria "0.7.2" e
+        # esconderia o patch. Feito aqui, e nao commitado, para nao divergir do
+        # upstream num arquivo que ele altera a cada release.
+        run: echo "${{ steps.meta.outputs.version }}" > VERSION
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Sem attestation de proveniencia: ela acrescenta uma entrada
+          # "unknown/unknown" ao manifest e polui a listagem do pacote.
+          provenance: false
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+
+      - name: Image digest
+        run: echo "ghcr.io/saphiracode/evolution-go@${{ steps.build.outputs.digest }}"

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1,3 +1,16 @@
+// This file was modified by Saphira Code from the original Evolution Go source,
+// as required by Section 4(b) of the Apache License 2.0.
+//
+// Change: StartClient no longer builds a sqlstore.Container per call. The
+// process now shares a single container, created lazily by getWAContainer and
+// backed — on Postgres — by the already-pooled authDB handle. The original code
+// called sqlstore.New on every instance (re)start, which opened a fresh *sql.DB
+// each time, and container.Close() was never called anywhere, so every
+// reconnect cycle stranded one idle Postgres connection until the connection
+// pool was exhausted and QR pairing stopped working.
+//
+// Licensed under the Apache License, Version 2.0 — see LICENSE.
+
 package whatsmeow_service
 
 import (
@@ -97,6 +110,7 @@ type whatsmeowService struct {
 	natsProducer       producer_interfaces.Producer
 	loggerWrapper      *logger_wrapper.LoggerManager
 	passkeyCeremony    *ceremony.Store
+	waContainer        *waContainerHolder
 }
 
 type MyClient struct {
@@ -301,12 +315,77 @@ func (w whatsmeowService) ForceUpdateJid(instanceId string, number string) error
 	return nil
 }
 
+// waContainerHolder guarda o unico sqlstore.Container do processo. E ponteiro
+// porque os metodos de whatsmeowService tem receiver por valor: um campo direto
+// seria copiado a cada chamada e o cache nunca sobreviveria.
+type waContainerHolder struct {
+	mu   sync.Mutex
+	cont *sqlstore.Container
+}
+
+// getWAContainer devolve o Container unico do processo, criando-o na primeira
+// chamada.
+//
+// sqlstore.Container e, por design, "a wrapper for a SQL database that can
+// contain multiple whatsmeow sessions" — um so atende todas as instancias.
+// Criar um por StartClient (como era antes) chamava sqlstore.New a cada
+// (re)inicio de instancia, e sqlstore.New faz sql.Open: um *sql.DB novo, com
+// pool proprio, seguido de Upgrade(). Como container.Close() nunca era chamado
+// e o Go nao fecha conexoes de database/sql no GC, cada ciclo de reconexao
+// deixava uma conexao Postgres ociosa presa para sempre, ate esgotar o pool do
+// PgBouncer e travar a geracao de QR code (DENT-248).
+//
+// No caminho Postgres reaproveitamos w.authDB, que aponta para o mesmo DSN
+// (POSTGRES_AUTH_DB) e ja vem com pool configurado por initPostgresAuthDB
+// (MaxOpenConns/MaxIdleConns/ConnMaxLifetime/ConnMaxIdleTime). Assim o whatsmeow
+// passa a respeitar o mesmo teto do resto da aplicacao em vez de abrir pools
+// ilimitados por fora dela.
+//
+// A criacao e preguicosa, e nao no construtor, para que um banco indisponivel no
+// boot nao deixe o processo permanentemente quebrado: a proxima chamada tenta de
+// novo.
+func (w whatsmeowService) getWAContainer() (*sqlstore.Container, error) {
+	w.waContainer.mu.Lock()
+	defer w.waContainer.mu.Unlock()
+
+	if w.waContainer.cont != nil {
+		return w.waContainer.cont, nil
+	}
+
+	var dbLog waLog.Logger
+	if w.config.WaDebug != "" {
+		dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+	}
+
+	var (
+		cont *sqlstore.Container
+		err  error
+	)
+
+	if w.config.PostgresAuthDB != "" {
+		if w.authDB == nil {
+			return nil, fmt.Errorf("POSTGRES_AUTH_DB is set but the auth DB handle was not initialized")
+		}
+		cont = sqlstore.NewWithDB(w.authDB, "postgres", dbLog)
+		err = cont.Upgrade(context.Background())
+	} else {
+		dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+		cont, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	w.waContainer.cont = cont
+	return cont, nil
+}
+
 func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("Starting websocket connection to Whatsapp for user '%s'", cd.Instance.Id)
 
 	var deviceStore *store.Device
-	var err error
 
 	if w.clientPointer[cd.Instance.Id] != nil {
 		if w.clientPointer[cd.Instance.Id].IsConnected() {
@@ -314,25 +393,9 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 		}
 	}
 
-	var container *sqlstore.Container
-
-	if w.config.WaDebug != "" {
-		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
-		}
-	} else {
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)
-		}
-	}
-
+	// Container unico do processo — ver getWAContainer. Antes era um
+	// sqlstore.New por chamada, que vazava uma conexao Postgres por reconexao.
+	container, err := w.getWAContainer()
 	if err != nil {
 		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to create container: %v", cd.Instance.Id, err)
 		return
@@ -2831,6 +2894,7 @@ func NewWhatsmeowService(
 		natsProducer:       natsProducer,
 		loggerWrapper:      loggerWrapper,
 		passkeyCeremony:    ceremony.NewStore(),
+		waContainer:        &waContainerHolder{},
 	}
 }
 


### PR DESCRIPTION
StartClient called sqlstore.New on every instance (re)start. sqlstore.New does sql.Open, so each call created a brand new *sql.DB with its own pool, and container.Close() is never called anywhere in the tree. Go does not close database/sql connections on GC, so every reconnect cycle (events.Disconnected -> ReconnectClient -> StartInstance -> StartClient) stranded an idle Postgres connection for the lifetime of the process.

The leak is constant and independent of tenant count: roughly one connection every two minutes, which is the reconnect cadence. Behind a PgBouncer in session mode each stranded client holds a server slot, so the pool saturates, queries queue past query_wait_timeout, and the app starts failing with "failed to upgrade database: driver: bad connection" — QR pairing stops working entirely.

sqlstore.Container is documented as "a wrapper for a SQL database that can contain multiple whatsmeow sessions", so one instance serves every client. This creates it once, lazily, and reuses it.

On Postgres it is now built with sqlstore.NewWithDB over the existing authDB handle, which points at the same DSN (POSTGRES_AUTH_DB) and already carries the pool limits set in initPostgresAuthDB (MaxOpenConns, MaxIdleConns, ConnMaxLifetime, ConnMaxIdleTime). The whatsmeow store was the only pool in the tree without them. On SQLite the behaviour is unchanged apart from being created once.

Creation is lazy rather than done in the constructor so that a database that is unavailable at boot does not leave the process permanently broken.

Also adds a workflow publishing the image to GHCR on tag, and the Apache 2.0 section 4(b) modification notice on the changed file.

## Description
<!-- Describe your changes in detail -->

## Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing
- [ ] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced

## Screenshots (if applicable)

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have tested my changes thoroughly
- [ ] Any dependent changes have been merged and published

## Additional Notes

## Summary by Sourcery

Reuse one lazily initialized WhatsApp SQL store across client restarts and publish tagged ARM64 images to GHCR.

Bug Fixes:
- Prevent PostgreSQL connection leaks during WhatsApp client reconnects by reusing a single sqlstore container across all client starts.
- Reuse the existing pooled authentication database for the WhatsApp store and preserve lazy initialization when the database is unavailable at startup.

CI:
- Add a tag-triggered workflow to build and publish immutable linux/arm64 images to GHCR.

Documentation:
- Add the Apache 2.0 Section 4(b) modification notice to the changed WhatsApp service file.