### PR TITLE
fix(instance): do not clear event subscriptions on disconnect

### DIFF
--- a/pkg/instance/service/instance_service.go
+++ b/pkg/instance/service/instance_service.go
@@ -311,10 +311,13 @@ func (i instances) Disconnect(instance *instance_model.Instance) (*instance_mode
 			i.loggerWrapper.GetLogger(instance.Id).LogInfo("[%s] Disconnection successful", instance.Id)
 			i.killChannel[instance.Id] <- true
 
-			instance.Events = ""
-
-			err := i.instanceRepository.Update(instance)
-			if err != nil {
+			// Do not clear instance.Events on disconnect. Wiping subscriptions
+			// leaves the instance "connected" after reconnect with an empty
+			// events string, and CallWebhook then drops every webhook (Go's
+			// strings.Split("", ",") yields [""], which fails IsEventType).
+			instance.Connected = false
+			instance.DisconnectReason = "Disconnected by API"
+			if err := i.instanceRepository.UpdateConnected(instance.Id, false, instance.DisconnectReason); err != nil {
 				return instance, err
 			}
 


### PR DESCRIPTION
## Summary
- `Disconnect` was wiping `instance.Events` before persisting the instance.
- After `reconnect`/`connect`, the instance looked connected but `CallWebhook` built an empty subscription list (`strings.Split("", ",")` yields `[""]`, which fails `IsEventType`), so every webhook was dropped.
- Keep event subscriptions on disconnect and only mark the instance as disconnected via `UpdateConnected`.

## Reproduction
1. Instance connected with `events=MESSAGE,CONNECTION,...` and a webhook URL.
2. `POST /instance/disconnect`
3. `POST /instance/reconnect` (or connect again)
4. Instance reports Connected/LoggedIn, but `events` is empty and inbound WhatsApp messages never reach the webhook.

## Test plan
- [ ] Disconnect an instance with non-empty `events`
- [ ] Confirm `GET /instance/info/{id}` still shows the previous `events` string
- [ ] Reconnect and send a test message → webhook delivers `Message`
- [ ] Confirm `connected=false` / disconnect reason after disconnect


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Preserve event subscriptions when disconnecting instances so reconnects continue to route webhook events correctly.

Bug Fixes:
- Preserve instance event subscriptions across disconnects so webhooks continue delivering events after reconnecting.

Enhancements:
- Update only the instance connection state and disconnect reason when disconnecting.