### PR TITLE
fix(whatsmeow): rotear Chat para DestinationJID em mensagens enviadas por aparelhos vinculados (multi-device)

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1223,6 +1223,17 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			}
 		}
 
+		// Trata mensagens enviadas em multi-device (celular primário / WhatsApp Web)
+		// O whatsmeow preenche evt.Info.Chat como o próprio número da empresa e armazena o lead de destino
+		// em evt.Info.DeviceSentMeta.DestinationJID.
+		if evt.Info.IsFromMe && evt.Info.DeviceSentMeta != nil && evt.Info.DeviceSentMeta.DestinationJID != "" && !evt.Info.IsGroup {
+			if destJID, err := types.ParseJID(evt.Info.DeviceSentMeta.DestinationJID); err == nil && !destJID.IsEmpty() {
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Outbound multi-device message detected - routing Chat from %s to DestinationJID %s",
+					mycli.userID, evt.Info.Chat.String(), destJID.String())
+				evt.Info.Chat = destJID
+			}
+		}
+
 		// Auto-marca mensagens como lidas se configurado
 		if mycli.Instance.ReadMessages && !evt.Info.IsFromMe {
 			go func() {
@@ -1264,6 +1275,15 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		dataMap, ok := postMap["data"].(map[string]interface{})
 		if !ok {
 			dataMap = make(map[string]interface{})
+		}
+
+		if evt.Info.IsFromMe && evt.Info.DeviceSentMeta != nil && evt.Info.DeviceSentMeta.DestinationJID != "" {
+			dataMap["recipient"] = evt.Info.DeviceSentMeta.DestinationJID
+			dataMap["Recipient"] = evt.Info.DeviceSentMeta.DestinationJID
+			if !evt.Info.IsGroup {
+				dataMap["chat"] = evt.Info.Chat.String()
+				dataMap["Chat"] = evt.Info.Chat.String()
+			}
 		}
 
 		referral := extractReferralFromMessage(evt.Message)

--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1226,11 +1226,18 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		// Trata mensagens enviadas em multi-device (celular primário / WhatsApp Web)
 		// O whatsmeow preenche evt.Info.Chat como o próprio número da empresa e armazena o lead de destino
 		// em evt.Info.DeviceSentMeta.DestinationJID.
-		if evt.Info.IsFromMe && evt.Info.DeviceSentMeta != nil && evt.Info.DeviceSentMeta.DestinationJID != "" && !evt.Info.IsGroup {
+		var validDestJID *types.JID
+		if evt.Info.IsFromMe && evt.Info.DeviceSentMeta != nil && evt.Info.DeviceSentMeta.DestinationJID != "" {
 			if destJID, err := types.ParseJID(evt.Info.DeviceSentMeta.DestinationJID); err == nil && !destJID.IsEmpty() {
-				mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Outbound multi-device message detected - routing Chat from %s to DestinationJID %s",
-					mycli.userID, evt.Info.Chat.String(), destJID.String())
-				evt.Info.Chat = destJID
+				validDestJID = &destJID
+				if !evt.Info.IsGroup {
+					mycli.loggerWrapper.GetLogger(mycli.userID).LogInfo("[%s] Outbound multi-device message detected - routing Chat from %s to DestinationJID %s",
+						mycli.userID, evt.Info.Chat.String(), destJID.String())
+					evt.Info.Chat = destJID
+				}
+			} else if err != nil {
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogWarn("[%s] Failed to parse DestinationJID '%s': %v",
+					mycli.userID, evt.Info.DeviceSentMeta.DestinationJID, err)
 			}
 		}
 
@@ -1277,12 +1284,13 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			dataMap = make(map[string]interface{})
 		}
 
-		if evt.Info.IsFromMe && evt.Info.DeviceSentMeta != nil && evt.Info.DeviceSentMeta.DestinationJID != "" {
-			dataMap["recipient"] = evt.Info.DeviceSentMeta.DestinationJID
-			dataMap["Recipient"] = evt.Info.DeviceSentMeta.DestinationJID
+		if validDestJID != nil {
+			destStr := validDestJID.String()
+			dataMap["recipient"] = destStr
+			dataMap["Recipient"] = destStr
 			if !evt.Info.IsGroup {
-				dataMap["chat"] = evt.Info.Chat.String()
-				dataMap["Chat"] = evt.Info.Chat.String()
+				dataMap["chat"] = destStr
+				dataMap["Chat"] = destStr
 			}
 		}
 


### PR DESCRIPTION
### Descrição do Problema
Quando uma mensagem é enviada a partir de um aparelho vinculado (celular físico primário da conta ou WhatsApp Web multi-device), a biblioteca WhatsMeow emite o evento `*events.Message` com `IsFromMe = true`.

Nesse fluxo do WhatsMeow:
1. `evt.Info.Chat` é preenchido com o JID da **própria instância/empresa** (o remetente), e não com o contato de destino.
2. O contato real de destino fica armazenado exclusivamente em `evt.Info.DeviceSentMeta.DestinationJID`.

### Impacto
No payload JSON entregue pelos webhooks:
- O campo `Chat` chega com o próprio número do WhatsApp conectado em vez do número do cliente que recebeu a mensagem.
- O campo `Recipient` fica ausente ou não reflete o destinatário.
- Plataformas de CRM, sistemas de atendimento e bots que monitoram mensagens enviadas manualmente por atendentes para ativar **handover humano** ou registrar o histórico da conversa não conseguem identificar para qual contato a mensagem foi enviada.

### O que esta alteração faz
1. **Roteamento de Destino:** Se a mensagem for outbound (`IsFromMe = true`), contiver metadados multi-device (`DeviceSentMeta != nil`) e for uma conversa privada (`!IsGroup`), converte o `DestinationJID` em `types.JID` e atualiza `evt.Info.Chat` para o destinatário real.
2. **Campos no Webhook:** Popula explicitamente `Recipient` e `recipient` com o `DestinationJID`, além de garantir que `Chat` reflita o destinatário no `dataMap`.
3. **Preservação de Grupos:** Mensagens enviadas para grupos (`@g.us`) não são alteradas, preservando o JID do grupo em `Chat`.

### Como foi testado
- Validado com stanzas reais de sincronização multi-device do WhatsMeow.
- Testado tanto com destinatários em formato tradicional (`@s.whatsapp.net`) quanto com identificadores LID (`@lid`).
- Confirmado que o webhook agora envia o JID correto do lead em `Chat` e `Recipient`, permitindo a conciliação imediata da conversa.

## Summary by Sourcery

Direcione mensagens outbound de multi-dispositivo ao destinatário correto nos eventos e webhooks, preservando o comportamento para grupos.

Bug Fixes:
- Corrija o roteamento de mensagens enviadas por aparelhos vinculados para identificar o destinatário real em conversas privadas.
- Preencha os campos `Chat` e `Recipient` dos webhooks com o JID de destino, incluindo destinatários em formato tradicional e LID.

Enhancements:
- Preserve o JID original de grupos e adicione tratamento de destinos inválidos sem interromper o processamento.