### PR TITLE
fix: prevent auto-reconnect during QR pairing phase

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1982,12 +1982,51 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		}
 
 		// Trigger instance restart via websocket-capable service (non-blocking)
-		go func(instanceID string) {
-			mycli.loggerWrapper.GetLogger(instanceID).LogInfo("[%s] Disconnected detected, restarting instance", instanceID)
-			if err := mycli.service.ReconnectClient(instanceID); err != nil {
-				mycli.loggerWrapper.GetLogger(instanceID).LogError("[%s] Failed to restart instance: %v", instanceID, err)
-			}
-		}(mycli.userID)
+		// -- but ONLY for an already-paired device (Store.ID set). While a
+		// device is still mid-QR-pairing (Store.ID nil), handleQRCodes/
+		// teardownQR above is already the sole owner of this instance's
+		// restart lifecycle, on its own timer (60s/20s per code, 5-code
+		// max). *events.Disconnected fires routinely and repeatedly during
+		// that handshake -- WhatsApp's servers cycle the socket several
+		// times before a device is actually paired -- and ReconnectClient()
+		// unconditionally tears down and restarts from scratch ("Creating
+		// new device"), racing the still-running QR-rotation goroutine over
+		// the same unsynchronized qrcodeCount. That collapsed the real
+		// ~140s pairing window down to a few seconds every time, so a QR
+		// code never survived long enough to actually be scanned. Gating
+		// this on Store.ID keeps the auto-heal for a real mid-session drop
+		// (the case this was written for) without it also firing on every
+		// pairing-phase blip.
+		if mycli.WAClient != nil && mycli.WAClient.Store.ID != nil {
+			go func(instanceID string) {
+				mycli.loggerWrapper.GetLogger(instanceID).LogInfo("[%s] Disconnected detected, restarting instance", instanceID)
+				if err := mycli.service.ReconnectClient(instanceID); err != nil {
+					mycli.loggerWrapper.GetLogger(instanceID).LogError("[%s] Failed to restart instance: %v", instanceID, err)
+				}
+			}(mycli.userID)
+		} else if mycli.WAClient != nil {
+			// Still mid-QR-pairing. Not a no-op, though -- a genuinely dropped
+			// socket here (as opposed to the routine cycling handleQRCodes/
+			// teardownQR above already tolerates) would otherwise sit dead
+			// until the QR-max-count timeout eventually forces a restart, up
+			// to ~140s away. Reconnect the SAME client/session in place --
+			// same recovery idiom StartClient's own EOF-retry branch already
+			// uses (WAClient.Connect() again on an already-initialized
+			// client) -- rather than ReconnectClient()'s teardown-and-mint-
+			// a-new-device-identity path. This touches no shared instance
+			// maps or qrcodeCount, so it can't reintroduce the race this fix
+			// removed above.
+			go func(instanceID string) {
+				if mycli.WAClient.IsConnected() {
+					return // already recovered by the time this goroutine ran
+				}
+				if err := mycli.WAClient.Connect(); err != nil {
+					mycli.loggerWrapper.GetLogger(instanceID).LogWarn("[%s] Reconnect attempt during QR pairing failed: %v", instanceID, err)
+				} else {
+					mycli.loggerWrapper.GetLogger(instanceID).LogInfo("[%s] Reconnected during QR pairing (same session, no device reset)", instanceID)
+				}
+			}(mycli.userID)
+		}
 	case *events.LabelEdit:
 		doWebhook = true
 		postMap["event"] = "LabelEdit"


### PR DESCRIPTION
## Description

`*events.Disconnected` in `myEventHandler` unconditionally spawns a goroutine that calls `ReconnectClient()`, regardless of whether the device is still mid-pairing (`Store.ID == nil`) or already logged in.

During new-device QR pairing, `Disconnected` fires routinely and repeatedly — WhatsApp's servers cycle the socket several times before a device is actually paired — which is expected and already handled correctly by `handleQRCodes`/`teardownQR`'s own rotation timer (60s for the first code, 20s for each of the rest, 5-code max ≈ 140s total).

The problem is that `ReconnectClient()` *also* fires on every one of those routine pairing-phase disconnects, concurrently with the QR-rotation goroutine that's already running. Both paths touch the same unsynchronized `qrcodeCount` / instance maps, and `ReconnectClient()` unconditionally tears the client down and restarts it from scratch ("No jid found. Creating new device"). In practice this collapses the intended ~140s pairing window down to a few seconds — the max QR count gets hit almost immediately, well before a code can realistically be scanned, and the whole cycle repeats indefinitely.

## Related Issue

None filed yet — happy to open one and link it if preferred.

## Root cause (reproduced)

Captured logs from a real pairing attempt show the QR counter reaching its max (5) and forcing a logout/restart within a few seconds of `StartClient`, instead of the ~140s the rotation timer implies:

```
02:06:50 QR code generated #3 (max: 5)
02:06:53 QR code generated #3 (max: 5)   <- same count logged twice, back-to-back
02:06:56 QR code generated #3 (max: 5)
02:06:58 Disconnected detected, restarting instance
02:06:58 Starting reconnection process - simulating restart
...
02:07:01 Starting fresh instance
02:07:02 QR code generated #1 (max: 5)   <- device reset, counter restarts
02:07:02 QR code generated #2 (max: 5)
02:07:03 QR code generated #2 (max: 5)   <- duplicate count again
02:07:07 QR code generated #5 (max: 5)
02:07:07 Maximum QR code count reached (5), forcing logout and QRTimeout
```

## Fix

Only auto-reconnect on `*events.Disconnected` once the device is already paired (`mycli.WAClient.Store.ID != nil`). A disconnect that happens while still mid-QR-pairing is left entirely to the QR-rotation lifecycle that already owns it — this preserves the auto-heal behavior for the case it looks like it was written for (a real, already-paired session dropping), without it also firing on every pairing-phase blip.

After the fix, the same pairing attempt rotates cleanly on the documented schedule with no spurious restarts:

```
02:20:05 QR code generated #2 (max: 5)
02:20:25 QR code generated #3 (max: 5)   <- exactly 20s later
02:20:45 QR code generated #4 (max: 5)   <- exactly 20s later
02:21:05 QR code generated #5 (max: 5)   <- exactly 20s later, max reached as designed
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

Verified against a real pairing attempt (scanned QR successfully, `Store.ID` set) and a real message send/delivery/read-receipt afterward, confirming the already-paired auto-reconnect path is unaffected. `gofmt`-clean diff, no other files touched.

## Additional Notes

Found while integrating Evolution Go's WhatsApp gateway into a separate application — QR pairing was effectively non-functional before this fix (every attempt hit the race within a few seconds of the first code). Happy to adjust the approach if there's a preferred way to guard this instead.

## Summary by Sourcery

Keep QR pairing stable by separating pairing-phase recovery from post-pairing session reconnection.

Bug Fixes:
- Prevent QR pairing from being disrupted by destructive auto-reconnects triggered by routine disconnect events.
- Recover genuine pairing-phase connection drops by reconnecting the existing client session without resetting device state.

Enhancements:
- Preserve automatic reconnection for disconnects occurring after the device has been paired.