### PR TITLE
fix(whatsmeow): create the sqlstore container once instead of on every StartClient

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -301,12 +301,72 @@ func (w whatsmeowService) ForceUpdateJid(instanceId string, number string) error
 	return nil
 }
 
+// ============================================================================
+// The whatsmeow store container is created ONCE, not on every StartClient call.
+//
+// THE BUG: StartClient called sqlstore.New on every invocation and never closed
+// the previous container. Each sqlstore.New opens its own *sql.DB, and a
+// *sql.DB that is never closed keeps its TCP connections open forever — the
+// garbage collector does not reclaim them.
+//
+// This only hurts when an instance loops. A device logged out from the phone
+// does exactly that: reconnect -> no session -> QR -> nobody scans -> max QR
+// count -> forced logout -> Disconnected -> reconnect again. Every turn of that
+// loop leaked a whole connection pool.
+//
+// Measured in production on a 500-connection Postgres: one logged-out instance
+// produced 110 reconnects in 50 minutes and exhausted the server. From that
+// point on, EVERY other instance that dropped its websocket failed to come back
+// with "Failed to create container: pq: sorry, too many clients already" — a
+// single dead instance took the whole process down with it.
+//
+// The DSN is identical for every instance, so one container serves them all.
+// After the change: 10 StartClient calls, 4 connections in use.
+//
+// NOTE: the error is deliberately NOT memoized. A database that is briefly
+// unreachable on the first attempt must not poison the process for its whole
+// lifetime — hence a Mutex rather than sync.Once.
+// ============================================================================
+
+var (
+	sharedContainerMu sync.Mutex
+	sharedStore       *sqlstore.Container
+)
+
+func sharedContainer(w whatsmeowService) (*sqlstore.Container, error) {
+	sharedContainerMu.Lock()
+	defer sharedContainerMu.Unlock()
+
+	if sharedStore != nil {
+		return sharedStore, nil
+	}
+
+	var dbLog waLog.Logger
+	if w.config.WaDebug != "" {
+		dbLog = waLog.Stdout("Database", w.config.WaDebug, true)
+	}
+
+	var container *sqlstore.Container
+	var err error
+	if w.config.PostgresAuthDB != "" {
+		container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
+	} else {
+		dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
+		container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	sharedStore = container
+	return container, nil
+}
+
 func (w whatsmeowService) StartClient(cd *ClientData) {
 
 	w.loggerWrapper.GetLogger(cd.Instance.Id).LogInfo("Starting websocket connection to Whatsapp for user '%s'", cd.Instance.Id)
 
 	var deviceStore *store.Device
-	var err error
 
 	if w.clientPointer[cd.Instance.Id] != nil {
 		if w.clientPointer[cd.Instance.Id].IsConnected() {
@@ -314,25 +374,8 @@ func (w whatsmeowService) StartClient(cd *ClientData) {
 		}
 	}
 
-	var container *sqlstore.Container
-
-	if w.config.WaDebug != "" {
-		dbLog := waLog.Stdout("Database", w.config.WaDebug, true)
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, dbLog)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, dbLog)
-		}
-	} else {
-		if w.config.PostgresAuthDB != "" {
-			container, err = sqlstore.New(context.Background(), "postgres", w.config.PostgresAuthDB, nil)
-		} else {
-			dsn := fmt.Sprintf("file:%s/dbdata/main.db?_pragma=foreign_keys(1)&_busy_timeout=5000&cache=shared&mode=rwc&_journal_mode=WAL", w.exPath)
-			container, err = sqlstore.New(context.Background(), "sqlite", dsn, nil)
-		}
-	}
-
+	// The container is created once and shared — see sharedContainer below.
+	container, err := sharedContainer(w)
 	if err != nil {
 		w.loggerWrapper.GetLogger(cd.Instance.Id).LogError("[%s] Failed to create container: %v", cd.Instance.Id, err)
 		return


### PR DESCRIPTION
## The problem

`StartClient` calls `sqlstore.New` on every invocation and never closes the previous container. There is no `container.Close()` anywhere in the file.

Each `sqlstore.New` opens its own `*sql.DB`. A `*sql.DB` that is never closed keeps its TCP connections open for the lifetime of the process — the garbage collector does not reclaim them.

This is harmless while instances stay connected. It becomes fatal when one instance loops, and a device that was logged out from the phone does exactly that:

```
reconnect → no session → QR → nobody scans → max QR count reached
   → forced logout → Disconnected event → reconnect → ...
```

Every turn of that loop leaks a whole connection pool.

## Measured in production

A 500-connection Postgres, nine instances, one of them logged out from the phone at 21:06:

| | |
|---|---|
| reconnects in 50 minutes | **110** |
| QR codes generated | **1135** |
| connections leaked per reconnect | ~4.5 |
| time to exhaust the server | **44 minutes** |

At 21:50 the pool was gone, and from that point on **every other instance that dropped its websocket failed to come back**:

```
Disconnected detected, restarting instance
Failed to create container: failed to upgrade database:
  failed to check if version table is up to date: pq: sorry, too many clients already
```

Three unrelated numbers went silent for 14 hours because of one dead instance. All 500 connections were sitting `idle` when we found them — nothing was using them.

## The fix

The DSN is identical for every instance (`w.config.PostgresAuthDB`, or the same sqlite path), so there was never a reason for a container per instance. This creates it once and shares it.

After the change, same deployment: **10 `StartClient` calls, 4 connections in use.**

## Two notes on the implementation

**The error is not memoized.** A `sync.Once` would let a database that is briefly unreachable at the first attempt poison the process for its entire lifetime. A `Mutex` guarding a nil check retries until it succeeds, and only the success is stored.

**`var err error` was removed** from the top of `StartClient` because the new `:=` declares it. No behaviour change.

## Testing

Built against `main` (`go build ./...`, clean) and running in production on two separate Evolution GO processes.

Happy to split this differently or adjust naming if you prefer.

## Summary by Sourcery

Reuse a single whatsmeow SQL store container across client starts to prevent connection exhaustion during reconnect loops.

Bug Fixes:
- Prevent WhatsApp client restarts from leaking database connection pools by reusing a shared SQL store container.

Enhancements:
- Allow shared-container initialization to retry after transient database connection failures instead of permanently caching the initial error.