### PR TITLE
fix(whatsmeow): Archive event panics before reaching the webhook

### DIFF
--- a/pkg/whatsmeow/service/whatsmeow.go
+++ b/pkg/whatsmeow/service/whatsmeow.go
@@ -1817,6 +1817,27 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		doWebhook = true
 		postMap["event"] = "Archive"
 
+		// postMap["data"] still holds the raw event at this point, so the type
+		// assertion below panicked on every Archive event. Same marshal/unmarshal
+		// step every other case in this switch already does.
+		if postMap["data"] != nil {
+			jsonBytes, err := json.Marshal(postMap["data"])
+			if err != nil {
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogError("[%s] Failed to marshal postMap['data']: %v", mycli.userID, err)
+				return
+			}
+
+			var parsed map[string]interface{}
+			if err := json.Unmarshal(jsonBytes, &parsed); err != nil {
+				mycli.loggerWrapper.GetLogger(mycli.userID).LogError("[%s] Failed to unmarshal postMap['data'] to map[string]interface{}: %v", mycli.userID, err)
+				return
+			}
+
+			postMap["data"] = parsed
+		} else {
+			postMap["data"] = make(map[string]interface{})
+		}
+
 		dataMap := postMap["data"].(map[string]interface{})
 		dataMap["JID"] = evt.JID
 		dataMap["Timestamp"] = evt.Timestamp


### PR DESCRIPTION
## The problem

The `*events.Archive` case asserts `postMap["data"]` to `map[string]interface{}`, but at that point it still holds the raw event. The assertion panics every time a chat is archived:

```
[Client ERROR] Event handler panicked while handling a *events.Archive:
interface conversion: interface {} is *events.Archive, not map[string]interface {}
```

`postMap["data"]` is set to `rawEvt` before the switch, so this is not a race or an edge case — it fails on **every** Archive event, in every deployment.

## Why nobody noticed

whatsmeow recovers the panic in its event dispatcher and logs it at ERROR level. Nothing crashes, no instance drops. The Archive event simply never reaches the webhook, and the only trace is one line in the log.

We hit it 4 times in 24 hours on a small deployment while investigating something unrelated.

## The fix

Every other case in this switch marshals `postMap["data"]` to JSON and unmarshals it back into a map before asserting. `Archive` was the only one missing that step.

Six call sites perform this assertion. Five are already guarded (`Connected`, `PairSuccess`, `TemporaryBan`, `LoggedOut`, and `Message`, which uses the comma-ok form). This makes `Archive` the sixth.

## A note for reviewers

The marshal/unmarshal block is now repeated five times in this file, and it would read better as a small helper — something like `dataMapFrom(postMap)`. I kept the change minimal and matched the surrounding style instead, since extracting it would touch cases that currently work. Happy to send that as a follow-up if you'd prefer it.

## Testing

`go build ./...` against `main`, clean.

## Summary by Sourcery

Bug Fixes:
- Prevent Archive events from panicking before webhook delivery by converting their raw event data into the expected map format.